### PR TITLE
feat(core): 添加设计稿宽度设置(px转rem相关)，默认375，可设置为750

### DIFF
--- a/packages/core/src/App.ts
+++ b/packages/core/src/App.ts
@@ -36,6 +36,7 @@ interface AppOptionsConfig {
   config?: MApp;
   platform?: 'editor' | 'mobile' | 'tv' | 'pc';
   jsEngine?: 'browser' | 'hippy';
+  designWidth?: number;
   curPage?: Id;
   transformStyle?: (style: Record<string, any>) => Record<string, any>;
 }
@@ -55,6 +56,7 @@ class App extends EventEmitter {
 
   public platform = 'mobile';
   public jsEngine = 'browser';
+  public designWidth = 375;
 
   public components = new Map();
 
@@ -66,13 +68,14 @@ class App extends EventEmitter {
     this.env = new Env(options.ua);
     options.platform && (this.platform = options.platform);
     options.jsEngine && (this.jsEngine = options.jsEngine);
+    options.designWidth && (this.designWidth = options.designWidth);
 
     // 根据屏幕大小计算出跟节点的font-size，用于rem样式的适配
     if (this.platform === 'mobile' || this.platform === 'editor') {
       const calcFontsize = () => {
         let { width } = document.documentElement.getBoundingClientRect();
         width = Math.min(800, width);
-        const fontSize = width / 3.75;
+        const fontSize = width / (this.designWidth / 100);
         document.documentElement.style.fontSize = `${fontSize}px`;
       };
 


### PR DESCRIPTION
新增designWidth可选属性，用于支持不同的设计稿尺寸