### PR TITLE
fix(editor): 已选组件树形拖放时, layout 根据父窗口动态变化

### DIFF
--- a/packages/editor/src/layouts/sidebar/LayerPanel.vue
+++ b/packages/editor/src/layouts/sidebar/LayerPanel.vue
@@ -61,12 +61,12 @@ import type { ElTree } from 'element-plus';
 import { throttle } from 'lodash-es';
 
 import type { MNode, MPage } from '@tmagic/schema';
-import { NodeType } from '@tmagic/schema';
+import { MContainer, NodeType } from '@tmagic/schema';
 import StageCore from '@tmagic/stage';
 
 import type { EditorService } from '@editor/services/editor';
 import type { Services } from '@editor/type';
-
+import { Layout } from '@editor/type';
 import LayerMenu from './LayerMenu.vue';
 
 const throttleTime = 150;
@@ -104,8 +104,16 @@ const useDrop = (tree: Ref<InstanceType<typeof ElTree> | undefined>, editorServi
     return false;
   },
 
-  handleDragEnd() {
+  async handleDragEnd(e: any) {
     if (!tree.value) return;
+    const { data: node } = e;
+    const parent = editorService?.getParentById(node.id, false) as MContainer;
+    const layout = await editorService?.getLayout(parent);
+    node.style.position = layout;
+    if (layout === Layout.RELATIVE) {
+      node.style.top = 0;
+      node.style.left = 0;
+    }
     const { data } = tree.value;
     const [page] = data as [MPage];
     editorService?.update(page);

--- a/packages/editor/src/layouts/sidebar/LayerPanel.vue
+++ b/packages/editor/src/layouts/sidebar/LayerPanel.vue
@@ -67,6 +67,8 @@ import StageCore from '@tmagic/stage';
 import type { EditorService } from '@editor/services/editor';
 import type { Services } from '@editor/type';
 import { Layout } from '@editor/type';
+
+import LayerMenu from './LayerMenu.vue';
 import LayerMenu from './LayerMenu.vue';
 
 const throttleTime = 150;


### PR DESCRIPTION
当拖拽到不同的父节点时, 自身节点的position不会根据父容器变化