### PR TITLE
feat(editor): 多选菜单支持复制粘贴删除

### DIFF
--- a/packages/editor/src/layouts/workspace/Stage.vue
+++ b/packages/editor/src/layouts/workspace/Stage.vue
@@ -76,8 +76,8 @@ export default defineComponent({
     const stageWrap = ref<InstanceType<typeof ScrollViewer>>();
     const stageContainer = ref<HTMLDivElement>();
     const menu = ref<InstanceType<typeof ViewerMenu>>();
-    const isMultiSelect = ref<Boolean>(false);
 
+    const isMultiSelect = computed(() => services?.editorService.get('nodes')?.length > 1);
     const stageRect = computed(() => services?.uiService.get<StageRect>('stageRect'));
     const uiSelectMode = computed(() => services?.uiService.get<boolean>('uiSelectMode'));
     const root = computed(() => services?.editorService.get<MApp>('root'));
@@ -133,7 +133,7 @@ export default defineComponent({
       });
 
       stage?.on('multiSelect', (els: HTMLElement[]) => {
-        services?.editorService.multiSelect(els);
+        services?.editorService.multiSelect(els.map((el) => el.id));
       });
 
       stage?.on('update', (ev: UpdateEventData) => {
@@ -215,7 +215,6 @@ export default defineComponent({
 
       contextmenuHandler(e: MouseEvent) {
         e.preventDefault();
-        isMultiSelect.value = stage?.selectedDomList?.length ? stage.selectedDomList.length > 1 : false;
         menu.value?.show(e);
       },
 

--- a/packages/editor/src/layouts/workspace/ViewerMenu.vue
+++ b/packages/editor/src/layouts/workspace/ViewerMenu.vue
@@ -31,6 +31,7 @@ export default defineComponent({
     const canPaste = ref(false);
     const canCenter = ref(false);
 
+    const node = computed(() => editorService?.get<MNode>('node'));
     const nodes = computed(() => editorService?.get<MNode[]>('nodes'));
     const parent = computed(() => editorService?.get('parent'));
     const stage = computed(() => editorService?.get<StageCore>('stage'));
@@ -43,8 +44,8 @@ export default defineComponent({
         text: '水平居中',
         display: () => canCenter.value && !props.isMultiSelect,
         handler: () => {
-          if (!nodes.value) return;
-          editorService?.alignCenter(nodes.value[0]);
+          if (!node.value) return;
+          editorService?.alignCenter(node.value);
         },
       },
       {
@@ -74,18 +75,15 @@ export default defineComponent({
         type: 'divider',
         direction: 'horizontal',
         display: () => {
-          if (!nodes.value) return false;
-          return !isPage(nodes.value[0]);
+          if (!node.value) return false;
+          return !isPage(node.value);
         },
       },
       {
         type: 'button',
         text: '上移一层',
         icon: markRaw(Top),
-        display: () => {
-          if (!nodes.value) return false;
-          return !isPage(nodes.value[0]) && !props.isMultiSelect;
-        },
+        display: () => !isPage(node.value) && !props.isMultiSelect,
         handler: () => {
           editorService?.moveLayer(1);
         },
@@ -94,10 +92,7 @@ export default defineComponent({
         type: 'button',
         text: '下移一层',
         icon: markRaw(Bottom),
-        display: () => {
-          if (!nodes.value) return false;
-          return !isPage(nodes.value[0]) && !props.isMultiSelect;
-        },
+        display: () => !isPage(node.value) && !props.isMultiSelect,
         handler: () => {
           editorService?.moveLayer(-1);
         },
@@ -105,10 +100,7 @@ export default defineComponent({
       {
         type: 'button',
         text: '置顶',
-        display: () => {
-          if (!nodes.value) return false;
-          return !isPage(nodes.value[0]) && !props.isMultiSelect;
-        },
+        display: () => !isPage(node.value) && !props.isMultiSelect,
         handler: () => {
           editorService?.moveLayer(LayerOffset.TOP);
         },
@@ -116,10 +108,7 @@ export default defineComponent({
       {
         type: 'button',
         text: '置底',
-        display: () => {
-          if (!nodes.value) return false;
-          return !nodes.value || (!isPage(nodes.value[0]) && !props.isMultiSelect);
-        },
+        display: () => !isPage(node.value) && !props.isMultiSelect,
         handler: () => {
           editorService?.moveLayer(LayerOffset.BOTTOM);
         },
@@ -127,19 +116,13 @@ export default defineComponent({
       {
         type: 'divider',
         direction: 'horizontal',
-        display: () => {
-          if (!nodes.value) return false;
-          return !isPage(nodes.value[0]) && !props.isMultiSelect;
-        },
+        display: () => !isPage(node.value) && !props.isMultiSelect,
       },
       {
         type: 'button',
         text: '删除',
         icon: Delete,
-        display: () => {
-          if (!nodes.value) return false;
-          return !isPage(nodes.value[0]);
-        },
+        display: () => !isPage(node.value),
         handler: () => {
           nodes.value && editorService?.remove(nodes.value);
         },

--- a/packages/editor/src/layouts/workspace/Workspace.vue
+++ b/packages/editor/src/layouts/workspace/Workspace.vue
@@ -34,7 +34,7 @@ export default defineComponent({
   setup() {
     const services = inject<Services>('services');
     const workspace = ref<HTMLDivElement>();
-    const node = computed(() => services?.editorService.get<MNode>('node'));
+    const nodes = computed(() => services?.editorService.get<MNode[]>('nodes'));
     let keycon: KeyController;
 
     const mouseenterHandler = () => {
@@ -58,27 +58,27 @@ export default defineComponent({
       keycon
         .keyup('delete', (e) => {
           e.inputEvent.preventDefault();
-          if (!node.value || isPage(node.value)) return;
-          services?.editorService.remove(node.value);
+          if (!nodes.value || isPage(nodes.value[0])) return;
+          services?.editorService.remove(nodes.value);
         })
         .keyup('backspace', (e) => {
           e.inputEvent.preventDefault();
-          if (!node.value || isPage(node.value)) return;
-          services?.editorService.remove(node.value);
+          if (!nodes.value || isPage(nodes.value[0])) return;
+          services?.editorService.remove(nodes.value);
         })
         .keydown([ctrl, 'c'], (e) => {
           e.inputEvent.preventDefault();
-          node.value && services?.editorService.copy(node.value);
+          nodes.value && services?.editorService.copy(nodes.value);
         })
         .keydown([ctrl, 'v'], (e) => {
           e.inputEvent.preventDefault();
-          node.value && services?.editorService.paste();
+          nodes.value && services?.editorService.paste();
         })
         .keydown([ctrl, 'x'], (e) => {
           e.inputEvent.preventDefault();
-          if (!node.value || isPage(node.value)) return;
-          services?.editorService.copy(node.value);
-          services?.editorService.remove(node.value);
+          if (!nodes.value || isPage(nodes.value[0])) return;
+          services?.editorService.copy(nodes.value);
+          services?.editorService.remove(nodes.value);
         })
         .keydown([ctrl, 'z'], (e) => {
           e.inputEvent.preventDefault();

--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -292,7 +292,7 @@ class Editor extends BaseService {
   public async add(addNode: AddMNode, parent?: MContainer | null): Promise<MNode> {
     // 加入inputEvent是为给业务扩展时可以获取到更多的信息，只有在使用拖拽添加组件时才有改对象
     const { type, inputEvent, ...config } = addNode;
-    const curNode = this.get<MContainer>('nodes')[0];
+    const curNode = this.get<MContainer>('node');
 
     let parentNode: MContainer | undefined;
     const isPage = type === NodeType.PAGE;
@@ -469,7 +469,7 @@ class Editor extends BaseService {
   public async paste(position: PastePosition = {}): Promise<MNode | void> {
     let pastePosition = position;
     const configStr = globalThis.localStorage.getItem(COPY_STORAGE_KEY);
-    const curNode = this.get<MContainer>('nodes')[0];
+    const curNode = this.get<MContainer>('node');
     // eslint-disable-next-line prefer-const
     let config: any = {};
     if (!configStr) {
@@ -498,7 +498,7 @@ class Editor extends BaseService {
    */
   public async alignCenter(config: MNode): Promise<MNode | void> {
     const parent = this.get<MContainer>('parent');
-    const node = this.get<MNode>('nodes')[0];
+    const node = this.get<MNode>('node');
     const layout = await this.getLayout(toRaw(parent), toRaw(node));
     if (layout === Layout.RELATIVE) {
       return;

--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -268,17 +268,18 @@ class Editor extends BaseService {
 
   /**
    * 多选
-   * @param config 指定节点配置或者ID
+   * @param ids 指定节点ID
    * @returns 加入多选的节点配置
    */
-  public multiSelect(config: Id[]): void {
+  public multiSelect(ids: Id[]): void {
     const nodes: MNode[] = [];
-    config.forEach((id) => {
+    const idsUnique = uniq(ids);
+    idsUnique.forEach((id) => {
       const { node } = this.getNodeInfo(id);
       if (!node) return;
       nodes.push(node);
     });
-    this.set('nodes', uniq(nodes));
+    this.set('nodes', nodes);
   }
 
   /**

--- a/packages/editor/src/type.ts
+++ b/packages/editor/src/type.ts
@@ -64,6 +64,7 @@ export interface StoreState {
   parent: MContainer | null;
   node: MNode | null;
   highlightNode: MNode | null;
+  selectedNodes: MNode[] | null;
   stage: StageCore | null;
   modifiedNodeIds: Map<Id, Id>;
   pageLength: number;

--- a/packages/editor/src/type.ts
+++ b/packages/editor/src/type.ts
@@ -64,7 +64,7 @@ export interface StoreState {
   parent: MContainer | null;
   node: MNode | null;
   highlightNode: MNode | null;
-  selectedNodes: MNode[] | null;
+  nodes: MNode[];
   stage: StageCore | null;
   modifiedNodeIds: Map<Id, Id>;
   pageLength: number;
@@ -128,6 +128,11 @@ export interface AddMNode {
   name?: string;
   inputEvent?: DragEvent;
   [key: string]: any;
+}
+
+export interface PastePosition {
+  left?: number;
+  top?: number;
 }
 
 /**

--- a/packages/editor/src/utils/operator.ts
+++ b/packages/editor/src/utils/operator.ts
@@ -1,0 +1,169 @@
+import { toRaw } from 'vue';
+import { cloneDeep } from 'lodash-es';
+
+import { Id, MApp, MContainer, MNode, NodeType } from '@tmagic/schema';
+import StageCore from '@tmagic/stage';
+import { isPage } from '@tmagic/utils';
+
+import editorService from '@editor/services/editor';
+import propsService from '@editor/services/props';
+import { AddMNode, Layout, PastePosition } from '@editor/type';
+import { fixNodeLeft, generatePageNameByApp, getInitPositionStyle, getNodeIndex } from '@editor/utils/editor';
+
+/**
+ * 粘贴前置操作：返回分配了新id以及校准了坐标的配置
+ * @param position 粘贴的坐标,如果为空则默认在元素坐标基础上偏移10px
+ * @param config 待粘贴的元素配置(复制时保存的那份配置)
+ * @returns
+ */
+export const beforePaste = async (position: PastePosition, config: MNode[]) => {
+  if (!config[0]?.style) return config;
+  const curNode = editorService.get<MContainer>('node');
+  // 将数组中第一个元素的坐标作为参照点
+  const { left: referenceLeft, top: referenceTop } = config[0].style;
+  // 坐标校准后的粘贴数据
+  const pasteConfigs: MNode[] = await Promise.all(
+    config.map(async (configItem: MNode): Promise<MNode> => {
+      let pastePosition = position;
+      if (curNode.items) {
+        // 如果粘贴时选中了容器，则将元素粘贴到容器内，坐标需要转换为相对于容器的坐标
+        pastePosition = getPositionInContainer(pastePosition, curNode.id);
+      }
+
+      // 将所有待粘贴元素坐标相对于多选第一个元素坐标重新计算，以保证多选粘贴后元素间距不变
+      if (pastePosition.left && configItem.style?.left) {
+        pastePosition.left = configItem.style.left - referenceLeft + pastePosition.left;
+      }
+      if (pastePosition.top && configItem.style?.top) {
+        pastePosition.top = configItem.style?.top - referenceTop + pastePosition.top;
+      }
+
+      const pasteConfig = await propsService.setNewItemId(configItem, editorService.get('root'));
+      if (pasteConfig.style) {
+        pasteConfig.style = {
+          ...pasteConfig.style,
+          ...pastePosition,
+        };
+      }
+      if (isPage(pasteConfig)) {
+        pasteConfig.name = generatePageNameByApp(editorService.get('root'));
+      }
+      return pasteConfig as MNode;
+    }),
+  );
+  return pasteConfigs;
+};
+
+/**
+ * 新增元素前置操作，实现了在编辑器中新增元素节点，并返回新增元素信息以供stage更新
+ * @param addNode 待添加元素的配置
+ * @param parent 父级容器（可选）
+ * @returns 新增的元素，父级元素，布局方式，是否为根页面
+ */
+export const beforeAdd = async (
+  addNode: AddMNode,
+  parent?: MContainer | null,
+): Promise<{ parentNode: MContainer; newNode: MNode; layout: Layout; isPage: boolean }> => {
+  // 加入inputEvent是为给业务扩展时可以获取到更多的信息，只有在使用拖拽添加组件时才有改对象
+  const { type, inputEvent, ...config } = addNode;
+  const curNode = editorService.get<MContainer>('node');
+
+  let parentNode: MContainer | undefined;
+  const isPage = type === NodeType.PAGE;
+
+  if (isPage) {
+    parentNode = editorService.get<MApp>('root');
+    // 由于支持中间件扩展，在parent参数为undefined时，parent会变成next函数
+  } else if (parent && typeof parent !== 'function') {
+    parentNode = parent;
+  } else if (curNode.items) {
+    parentNode = curNode;
+  } else {
+    parentNode = editorService.getParentById(curNode.id, false);
+  }
+
+  if (!parentNode) throw new Error('未找到父元素');
+
+  const layout = await editorService.getLayout(toRaw(parentNode), addNode as MNode);
+  const newNode = { ...toRaw(await propsService.getPropsValue(type, config)) };
+  newNode.style = getInitPositionStyle(newNode.style, layout, parentNode, editorService.get<StageCore>('stage'));
+
+  if ((parentNode?.type === NodeType.ROOT || curNode.type === NodeType.ROOT) && newNode.type !== NodeType.PAGE) {
+    throw new Error('app下不能添加组件');
+  }
+  // 新增节点添加到配置中
+  parentNode?.items?.push(newNode);
+  // 返回新增信息以供stage更新
+  return {
+    parentNode,
+    newNode,
+    layout,
+    isPage,
+  };
+};
+
+/**
+ * 将元素粘贴到容器内时，将相对于画布坐标转换为相对于容器的坐标
+ * @param position PastePosition 粘贴时相对于画布的坐标
+ * @param id 元素id
+ * @returns PastePosition 转换后的坐标
+ */
+export const getPositionInContainer = (position: PastePosition = {}, id: Id) => {
+  let { left = 0, top = 0 } = position;
+  const parentEl = editorService.get<StageCore>('stage')?.renderer?.contentWindow?.document.getElementById(`${id}`);
+  const parentElRect = parentEl?.getBoundingClientRect();
+  left = left - (parentElRect?.left || 0);
+  top = top - (parentElRect?.top || 0);
+  return {
+    left,
+    top,
+  };
+};
+
+/**
+ * 将新增元素事件通知到stage以更新渲染
+ * @param parentNode 父元素
+ * @param newNode 当前新增元素
+ * @param layout 布局方式
+ */
+export const notifyAddToStage = async (parentNode: MContainer, newNode: MNode, layout: Layout) => {
+  const stage = editorService.get<StageCore | null>('stage');
+  const root = editorService.get<MApp>('root');
+
+  await stage?.add({ config: cloneDeep(newNode), parent: cloneDeep(parentNode), root: cloneDeep(root) });
+
+  if (layout === Layout.ABSOLUTE) {
+    const fixedLeft = fixNodeLeft(newNode, parentNode, stage?.renderer.contentWindow?.document);
+    if (typeof fixedLeft !== 'undefined' && newNode.style) {
+      newNode.style.left = fixedLeft;
+      await stage?.update({ config: cloneDeep(newNode), root: cloneDeep(root) });
+    }
+  }
+};
+
+/**
+ * 删除前置操作：实现了在编辑器中删除元素节点，并返回父级元素信息以供stage更新
+ * @param node 待删除的节点
+ * @returns 父级元素，root根元素
+ */
+export const beforeRemove = (node: MNode): { parent: MContainer; root: MApp } | void => {
+  if (!node?.id) return;
+
+  const root = editorService.get<MApp | null>('root');
+
+  if (!root) throw new Error('没有root');
+
+  const { parent, node: curNode } = editorService.getNodeInfo(node.id, false);
+
+  if (!parent || !curNode) throw new Error('找不要删除的节点');
+
+  const index = getNodeIndex(curNode, parent);
+
+  if (typeof index !== 'number' || index === -1) throw new Error('找不要删除的节点');
+  // 从配置中删除元素
+  parent.items?.splice(index, 1);
+  return {
+    parent,
+    root,
+  };
+};

--- a/packages/editor/tests/unit/services/editor.spec.ts
+++ b/packages/editor/tests/unit/services/editor.spec.ts
@@ -353,7 +353,7 @@ describe('copy', () => {
     const node = editorService.getNodeById(NodeId.NODE_ID2);
     await editorService.copy(node!);
     const str = globalThis.localStorage.getItem(COPY_STORAGE_KEY);
-    expect(str).toBe(JSON.stringify(node));
+    expect(str).toBe(JSON.stringify([node]));
   });
 });
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -70,4 +70,9 @@ export interface MApp extends MComponent {
   items: MPage[];
 }
 
+export interface PastePosition {
+  left?: number;
+  top?: number;
+}
+
 export type MNode = MComponent | MContainer | MPage | MApp;

--- a/packages/stage/src/StageMask.ts
+++ b/packages/stage/src/StageMask.ts
@@ -331,6 +331,9 @@ export default class StageMask extends Rule {
   private mouseUpHandler = (): void => {
     globalThis.document.removeEventListener('mouseup', this.mouseUpHandler);
     this.content.addEventListener('mousemove', this.highlightHandler);
+    if (!this.isMultiSelectStatus) {
+      this.emit('select');
+    }
   };
 
   private mouseWheelHandler = (event: WheelEvent) => {

--- a/packages/stage/src/StageMask.ts
+++ b/packages/stage/src/StageMask.ts
@@ -331,7 +331,6 @@ export default class StageMask extends Rule {
   private mouseUpHandler = (): void => {
     globalThis.document.removeEventListener('mouseup', this.mouseUpHandler);
     this.content.addEventListener('mousemove', this.highlightHandler);
-    this.emit('select');
   };
 
   private mouseWheelHandler = (event: WheelEvent) => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -127,7 +127,10 @@ export const getUrlParam = (param: string, url?: string) => {
 
 export const isPop = (node: MNode): boolean => Boolean(node.type?.toLowerCase().endsWith('pop'));
 
-export const isPage = (node: MNode): boolean => Boolean(node.type?.toLowerCase() === NodeType.PAGE);
+export const isPage = (node: MNode | undefined): boolean => {
+  if (!node) return false;
+  return Boolean(node.type?.toLowerCase() === NodeType.PAGE);
+};
 
 export const isNumber = (value: string) => /^(-?\d+)(\.\d+)?$/.test(value);
 


### PR DESCRIPTION
1、多选右键菜单支持复制粘贴删除
2、编辑器选中节点统一为nodes数组,保留原node对象为nodes数组的第一个元素
3、将复制粘贴删除行为封装到editorservice中
4、支持键盘快捷键操作
5、将复制粘贴操作拆分后进一步封装