### PR TITLE
refactor: 添加editorService.getStorage方法

### DIFF
--- a/packages/editor/src/layouts/workspace/ViewerMenu.vue
+++ b/packages/editor/src/layouts/workspace/ViewerMenu.vue
@@ -141,8 +141,9 @@ export default defineComponent({
       ...stageContentMenu,
     ]);
 
-    onMounted(() => {
-      const data = globalThis.localStorage.getItem(COPY_STORAGE_KEY);
+    onMounted(async () => {
+      const storage = await editorService?.getStorage();
+      const data = storage?.getItem(COPY_STORAGE_KEY);
       canPaste.value = data !== 'undefined' && !!data;
     });
 

--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -60,6 +60,7 @@ class Editor extends BaseService {
     super(
       [
         'getLayout',
+        'getStorage',
         'select',
         'add',
         'remove',
@@ -423,12 +424,21 @@ class Editor extends BaseService {
   }
 
   /**
+   * 获取数据存储对象
+   * @returns Storage
+   */
+  public async getStorage(): Promise<Storage> {
+    return globalThis.localStorage;
+  }
+
+  /**
    * 将组将节点配置转化成string，然后存储到localStorage中
    * @param config 组件节点配置
    * @returns 组件节点配置
    */
   public async copy(config: MNode | MNode[]): Promise<void> {
-    globalThis.localStorage.setItem(COPY_STORAGE_KEY, serialize(Array.isArray(config) ? config : [config]));
+    const storage = await this.getStorage();
+    storage.setItem(COPY_STORAGE_KEY, serialize(Array.isArray(config) ? config : [config]));
   }
 
   /**
@@ -437,7 +447,8 @@ class Editor extends BaseService {
    * @returns 添加后的组件节点配置
    */
   public async paste(position: PastePosition = {}): Promise<MNode[] | void> {
-    const configStr = globalThis.localStorage.getItem(COPY_STORAGE_KEY);
+    const storage = await this.getStorage();
+    const configStr = storage.getItem(COPY_STORAGE_KEY);
     // eslint-disable-next-line prefer-const
     let config: any = {};
     if (!configStr) {

--- a/packages/editor/tests/unit/services/editor.spec.ts
+++ b/packages/editor/tests/unit/services/editor.spec.ts
@@ -352,7 +352,8 @@ describe('copy', () => {
   test('正常', async () => {
     const node = editorService.getNodeById(NodeId.NODE_ID2);
     await editorService.copy(node!);
-    const str = globalThis.localStorage.getItem(COPY_STORAGE_KEY);
+    const storage = await editorService.getStorage();
+    const str = storage.getItem(COPY_STORAGE_KEY);
     expect(str).toBe(JSON.stringify([node]));
   });
 });


### PR DESCRIPTION
复制粘贴的功能通过localStorage存储，存在污染另一个标签页画布数据的情况。通过拓展getStorage方法，实现使用sessionStorage对象存储copy源数据。

`editorService.use({
  async getStorage(): Promise<Storage> {
    return window.sessionStorage;
  },
});`