### PR TITLE
fix(editor): 修复添加StorageService定义导出带来的构建错误

### DIFF
--- a/packages/editor/src/Editor.vue
+++ b/packages/editor/src/Editor.vue
@@ -61,6 +61,7 @@ import editorService from '@editor/services/editor';
 import eventsService from '@editor/services/events';
 import historyService from '@editor/services/history';
 import propsService from '@editor/services/props';
+import storageService from '@editor/services/storage';
 import uiService from '@editor/services/ui';
 import type { ComponentGroup, MenuBarData, MenuItem, Services, SideBarData, StageRect } from '@editor/type';
 
@@ -269,6 +270,7 @@ export default defineComponent({
       propsService,
       editorService,
       uiService,
+      storageService,
     };
 
     provide('services', services);


### PR DESCRIPTION
1.修复添加StorageService定义导出带来的构建错误

已本地构建验证