### PR TITLE
fix(editor): 修复执行构建生成*.d.ts时部分文件丢失（editor.d.ts）和 添加组件粘贴操作支持偏移量

### DIFF
--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { reactive, toRaw } from 'vue';
+import { reactive, toRaw, UnwrapNestedRefs } from 'vue';
 import { cloneDeep, mergeWith, uniq } from 'lodash-es';
 
 import type { Id, MApp, MComponent, MContainer, MNode, MPage } from '@tmagic/schema';
@@ -42,7 +42,7 @@ import { beforeAdd, beforePaste, beforeRemove, notifyAddToStage } from '@editor/
 import BaseService from './BaseService';
 
 class Editor extends BaseService {
-  public state = reactive<StoreState>({
+  public state: UnwrapNestedRefs<StoreState> = reactive<StoreState>({
     root: null,
     page: null,
     parent: null,

--- a/packages/editor/src/type.ts
+++ b/packages/editor/src/type.ts
@@ -135,6 +135,14 @@ export interface AddMNode {
 export interface PastePosition {
   left?: number;
   top?: number;
+  /**
+   * 粘贴位置X方向偏移量
+   */
+  offsetX?: number;
+  /**
+   * 粘贴位置Y方向偏移量
+   */
+  offsetY?: number;
 }
 
 /**

--- a/packages/editor/src/utils/operator.ts
+++ b/packages/editor/src/utils/operator.ts
@@ -25,7 +25,10 @@ export const beforePaste = async (position: PastePosition, config: MNode[]) => {
   // 坐标校准后的粘贴数据
   const pasteConfigs: MNode[] = await Promise.all(
     config.map(async (configItem: MNode): Promise<MNode> => {
-      let pastePosition = position;
+      // 解构 position 对象，从 position 删除 offsetX、offsetY字段
+      const { offsetX = 0, offsetY = 0, ...positionClone } = position;
+      let pastePosition = positionClone;
+
       if (!isEmpty(pastePosition) && curNode.items) {
         // 如果没有传入粘贴坐标则可能为键盘操作，不再转换
         // 如果粘贴时选中了容器，则将元素粘贴到容器内，坐标需要转换为相对于容器的坐标
@@ -34,14 +37,24 @@ export const beforePaste = async (position: PastePosition, config: MNode[]) => {
 
       // 将所有待粘贴元素坐标相对于多选第一个元素坐标重新计算，以保证多选粘贴后元素间距不变
       if (pastePosition.left && configItem.style?.left) {
-        pastePosition.left = configItem.style.left - referenceLeft + pastePosition.left;
+        pastePosition.left = configItem.style.left - referenceLeft + pastePosition.left + offsetX;
       }
       if (pastePosition.top && configItem.style?.top) {
-        pastePosition.top = configItem.style?.top - referenceTop + pastePosition.top;
+        pastePosition.top = configItem.style?.top - referenceTop + pastePosition.top + offsetY;
       }
 
       const pasteConfig = await propsService.setNewItemId(configItem, editorService.get('root'));
+
       if (pasteConfig.style) {
+        const { left, top } = pasteConfig.style;
+        // 判断能转换为数字时，做粘贴偏移量计算
+        if (typeof left === 'number' || (!!left && !isNaN(Number(left)))) {
+          pasteConfig.style.left = Number(left) + offsetX;
+        }
+        if (typeof top === 'number' || (!!top && !isNaN(Number(top)))) {
+          pasteConfig.style.top = Number(top) + offsetY;
+        }
+
         pasteConfig.style = {
           ...pasteConfig.style,
           ...pastePosition,

--- a/packages/editor/src/utils/operator.ts
+++ b/packages/editor/src/utils/operator.ts
@@ -37,10 +37,10 @@ export const beforePaste = async (position: PastePosition, config: MNode[]) => {
 
       // 将所有待粘贴元素坐标相对于多选第一个元素坐标重新计算，以保证多选粘贴后元素间距不变
       if (pastePosition.left && configItem.style?.left) {
-        pastePosition.left = configItem.style.left - referenceLeft + pastePosition.left + offsetX;
+        pastePosition.left = configItem.style.left - referenceLeft + pastePosition.left;
       }
       if (pastePosition.top && configItem.style?.top) {
-        pastePosition.top = configItem.style?.top - referenceTop + pastePosition.top + offsetY;
+        pastePosition.top = configItem.style?.top - referenceTop + pastePosition.top;
       }
 
       const pasteConfig = await propsService.setNewItemId(configItem, editorService.get('root'));


### PR DESCRIPTION
1. 修复editor由于修改私有变量为全局变量时未声明其类型，导致不能按预期构建生成其定义*.d.ts文件，当前只解决了editor.d.ts文件不生成的问题。 #230 
2. 添加组件粘贴操作支持偏移量