### PR TITLE
fix(editor): 拖拽改变父容器时错乱现象

### DIFF
--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -664,7 +664,8 @@ class Editor extends BaseService {
 
       await stage.select(targetId);
 
-      await stage.update({ config: cloneDeep(target), parentId: parent.id, root });
+      const targetParent = this.getParentById(target.id);
+      await stage.update({ config: cloneDeep(target), parentId: targetParent?.id, root });
 
       await this.select(newConfig);
       stage.select(newConfig.id);

--- a/packages/stage/src/types.ts
+++ b/packages/stage/src/types.ts
@@ -119,7 +119,7 @@ export interface SortEventData {
 export interface UpdateData {
   config: MNode;
   parent?: MContainer;
-  parentId: Id;
+  parentId: Id | undefined;
   root: MApp;
 }
 

--- a/packages/stage/src/types.ts
+++ b/packages/stage/src/types.ts
@@ -119,7 +119,7 @@ export interface SortEventData {
 export interface UpdateData {
   config: MNode;
   parent?: MContainer;
-  parentId: Id | undefined;
+  parentId?: Id;
   root: MApp;
 }
 


### PR DESCRIPTION
直接拖拽元素改变其父容器时， 会产生错乱的现象。修改完后测试了一下没问题了，但不确定这样修改完后，会不会对其它功能有影响。 
下图是修改前：
![l图片](https://p.qlogo.cn/hy_personal/3e28f14aa0516842d26cd9850b43c589ed4dfb3751a33ad79ed02c517a65cc56/0.png)