### PR TITLE
fix(editor): 修复Add返回数组还是对象的逻辑

### DIFF
--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -368,7 +368,7 @@ class Editor extends BaseService {
 
     this.emit('add', newNodes);
 
-    return newNodes.length > 1 ? newNodes[0] : newNodes;
+    return newNodes.length > 1 ? newNodes : newNodes[0];
   }
 
   public async doRemove(node: MNode): Promise<void> {


### PR DESCRIPTION
1、修复编辑器add单个对象，返回的是数组实力，三目运算符逻辑错误