### PR TITLE
feat(editor): 创建新组件时的顺序

### DIFF
--- a/packages/editor/src/services/editor.ts
+++ b/packages/editor/src/services/editor.ts
@@ -297,8 +297,13 @@ class Editor extends BaseService {
       throw new Error('app下不能添加组件');
     }
 
-    // 新增节点添加到配置中
-    parent?.items?.push(node);
+    if (parent.id !== curNode.id) {
+      const index = parent.items.indexOf(curNode);
+      parent?.items?.splice(index + 1, 0, node);
+    } else {
+      // 新增节点添加到配置中
+      parent?.items?.push(node);
+    }
 
     const layout = await this.getLayout(toRaw(parent), node as MNode);
     node.style = getInitPositionStyle(node.style, layout);

--- a/runtime/vue2/playground/App.vue
+++ b/runtime/vue2/playground/App.vue
@@ -71,7 +71,13 @@ export default defineComponent({
         if (!selectedId.value) throw new Error('error');
         const parent = getNodePath(parentId, [root.value]).pop();
         if (!parent) throw new Error('未找到父节点');
-        parent.items?.push(config);
+        if (parent.id !== selectedId.value) {
+          const index = parent.items?.findIndex((child: MNode) => child.id === selectedId.value);
+          parent.items?.splice(index + 1, 0, config);
+        } else {
+          // 新增节点添加到配置中
+          parent.items?.push(config);
+        }
       },
 
       update({ config, parentId }: UpdateData) {

--- a/runtime/vue3/playground/App.vue
+++ b/runtime/vue3/playground/App.vue
@@ -71,7 +71,13 @@ export default defineComponent({
         if (!selectedId.value) throw new Error('error');
         const parent = getNodePath(parentId, [root.value]).pop();
         if (!parent) throw new Error('未找到父节点');
-        parent.items?.push(config);
+        if (parent.id !== selectedId.value) {
+          const index = parent.items?.findIndex((child: MNode) => child.id === selectedId.value);
+          parent.items?.splice(index + 1, 0, config);
+        } else {
+          // 新增节点添加到配置中
+          parent.items?.push(config);
+        }
       },
 
       update({ config, parentId }: UpdateData) {


### PR DESCRIPTION
点击面板组件创建新组件时，默认按照当所选组件(非容器)后面的顺序。
这样在流式布局内，选中一个元素后， 再点击创建新元素时， 自动创建在该元素的后面，增强用户体验。