### PR TITLE
fix(editor): 点击page，再切换到容器元素，第一次点击无法正常添加组件

### DIFF
--- a/packages/editor/src/layouts/sidebar/ComponentListPanel.vue
+++ b/packages/editor/src/layouts/sidebar/ComponentListPanel.vue
@@ -19,7 +19,7 @@
             v-for="item in group.items"
             draggable="true"
             :key="item.type"
-            @click="appendComponent(item)"
+            @mousedown="appendComponent(item)"
             @dragstart="dragstartHandler(item, $event)"
             @dragend="dragendHandler"
             @drag="dragHandler"


### PR DESCRIPTION
点击选中page ，再选中别的元素，然后点击左侧组件，第一次点击无法正常添加组件， 发现并未触发click事件。
如果是选中非page组件，再选中别的元素是可以正常添加的。
操作演示如下: 
![操作演示](https://p.qlogo.cn/hy_personal/3e28f14aa05168424c632e6d62291fbb91f03f67a038fb44451aabbf92ff9e4f/0.png)