### PR TITLE
fix(ui): 修复text组件在流式容器内无宽高问题

### DIFF
--- a/packages/ui-react/src/text/Text.tsx
+++ b/packages/ui-react/src/text/Text.tsx
@@ -34,9 +34,9 @@ const Text: React.FC<TextProps> = ({ config }) => {
   const [displayText] = useState(config.text);
 
   return (
-    <p ref={ref} className="magic-ui-text" style={app.transformStyle(config.style || {})} id={`${config.id || ''}`}>
+    <div ref={ref} className="magic-ui-text" style={app.transformStyle(config.style || {})} id={`${config.id || ''}`}>
       {displayText}
-    </p>
+    </div>
   );
 };
 

--- a/packages/ui-vue2/src/text/Text.vue
+++ b/packages/ui-vue2/src/text/Text.vue
@@ -54,9 +54,9 @@ export default defineComponent({
   render() {
     const className = this.config?.multiple ? 'magic-ui-text' : 'magic-ui-text magic-ui-text--single-line';
     if (typeof this.$slots?.default === 'function') {
-      return h('span', { class: className }, [this.$slots?.default?.() || '']);
+      return h('div', { class: className }, [this.$slots?.default?.() || '']);
     }
-    return h('span', {
+    return h('div', {
       class: className,
       domProps: {
         innerHTML: this.displayText,

--- a/packages/ui/src/text/src/index.vue
+++ b/packages/ui/src/text/src/index.vue
@@ -52,9 +52,9 @@ export default defineComponent({
   render() {
     const className = this.config?.multiple ? 'magic-ui-text' : 'magic-ui-text magic-ui-text--single-line';
     if (typeof this.$slots?.default === 'function') {
-      return h('span', { class: className }, [this.$slots?.default?.() || '']);
+      return h('div', { class: className }, [this.$slots?.default?.() || '']);
     }
-    return h('span', {
+    return h('div', {
       class: className,
       ...(this.displayText ? { innerHTML: this.displayText } : {}),
     });


### PR DESCRIPTION
流式容器内添加文本组件时没有宽高， 操作如下：
![操作如下](https://p.qlogo.cn/hy_personal/3e28f14aa05168424c632e6d62291fbb38a579af611e13cc0d1b145503ffb594/0.png)