### PR TITLE
fix(playgound): npm run serve后runtime无法打开

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -23,8 +23,7 @@ import legacy from '@vitejs/plugin-legacy';
 import vue from '@vitejs/plugin-vue';
 import vueJsx from '@vitejs/plugin-vue-jsx';
 
-// https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     vue(),
     vueJsx(),
@@ -67,17 +66,19 @@ export default defineConfig({
     },
     host: '0.0.0.0',
     port: 8098,
-    proxy: {
-      '^/tmagic-editor/playground/runtime': {
-        target: 'http://127.0.0.1:8078',
-        changeOrigin: true,
-        prependPath: false,
-      },
-    },
+    proxy: command
+      ? undefined
+      : {
+          '^/tmagic-editor/playground/runtime': {
+            target: 'http://127.0.0.1:8078',
+            changeOrigin: true,
+            prependPath: false,
+          },
+        },
     open: '/tmagic-editor/playground/',
   },
 
   build: {
     sourcemap: true,
   },
-});
+}));


### PR DESCRIPTION
由于vite.config.ts中配置了proxy，run serve的时候是不需要proxy的

fix #352