### PR TITLE
fix(core): 修复多组件同一事件监听问题修改后导致的共通点击失效问题

### DIFF
--- a/packages/core/src/App.ts
+++ b/packages/core/src/App.ts
@@ -21,13 +21,7 @@ import { EventEmitter } from 'events';
 import type { EventItemConfig, Id, MApp } from '@tmagic/schema';
 
 import Env from './Env';
-import {
-  bindCommonEventListener,
-  DEFAULT_EVENTS,
-  getCommonEventName,
-  isCommonMethod,
-  triggerCommonMethod,
-} from './events';
+import { bindCommonEventListener, isCommonMethod, triggerCommonMethod } from './events';
 import type Node from './Node';
 import Page from './Page';
 import { fillBackgroundImage, isNumber, style2Obj } from './utils';
@@ -202,13 +196,8 @@ class App extends EventEmitter {
   }
 
   public bindEvent(event: EventItemConfig, id: string) {
-    let { name: eventName } = event;
-    if (DEFAULT_EVENTS.findIndex((defaultEvent) => defaultEvent.value === eventName) > -1) {
-      // common 事件名通过 node id 避免重复触发
-      eventName = getCommonEventName(eventName, id);
-    }
-
-    this.on(`${eventName}_${id}`, (fromCpt: Node, ...args) => {
+    const { name } = event;
+    this.on(`${name}_${id}`, (fromCpt: Node, ...args) => {
       this.eventHandler(event, fromCpt, args);
     });
   }

--- a/packages/core/src/App.ts
+++ b/packages/core/src/App.ts
@@ -206,7 +206,7 @@ class App extends EventEmitter {
     if (typeof node.data === 'undefined') {
       return super.emit(name, node, ...args);
     }
-    return super.emit(`${String(name)}_${node.data.id}`, ...args);
+    return super.emit(`${String(name)}_${node.data.id}`, node, ...args);
   }
 
   public eventHandler(eventConfig: EventItemConfig, fromCpt: any, args: any[]) {

--- a/packages/core/src/App.ts
+++ b/packages/core/src/App.ts
@@ -203,10 +203,10 @@ class App extends EventEmitter {
   }
 
   public emit(name: string | symbol, node: any, ...args: any[]): boolean {
-    if (typeof node.data === 'undefined') {
-      return super.emit(name, node, ...args);
+    if (node?.data?.id) {
+      return super.emit(`${String(name)}_${node.data.id}`, node, ...args);
     }
-    return super.emit(`${String(name)}_${node.data.id}`, node, ...args);
+    return super.emit(name, node, ...args);
   }
 
   public eventHandler(eventConfig: EventItemConfig, fromCpt: any, args: any[]) {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -41,12 +41,9 @@ export const DEFAULT_EVENTS: EventOption[] = [{ label: '点击', value: `${COMMO
 
 export const DEFAULT_METHODS: EventOption[] = [];
 
-export const getCommonEventName = (commonEventName: string, nodeId: string | number) => {
-  const returnName = `${commonEventName}:${nodeId}`;
-
-  if (commonEventName.startsWith(COMMON_EVENT_PREFIX)) return returnName;
-
-  return `${COMMON_EVENT_PREFIX}${returnName}`;
+export const getCommonEventName = (commonEventName: string) => {
+  if (commonEventName.startsWith(COMMON_EVENT_PREFIX)) return commonEventName;
+  return `${COMMON_EVENT_PREFIX}${commonEventName}`;
 };
 
 export const isCommonMethod = (methodName: string) => methodName.startsWith(COMMON_METHOD_PREFIX);
@@ -73,8 +70,7 @@ const commonClickEventHandler = (app: App, eventName: string, e: any) => {
   const node = getDirectComponent(e.target, app);
 
   if (node) {
-    const { instance, data } = node as Node;
-    app.emit(getCommonEventName(eventName, data.id), instance);
+    app.emit(getCommonEventName(eventName), node);
   }
 };
 


### PR DESCRIPTION
共通事件在监听事件时多加了一次_id，而emit并没有，导致共通click事件失效 ， 修改为统一自定义事件和共通事件行为。