### PR TITLE
fix(runtime): 切换设计窗体大小时，同时修改app

### DIFF
--- a/packages/core/src/App.ts
+++ b/packages/core/src/App.ts
@@ -70,8 +70,7 @@ class App extends EventEmitter {
     // 根据屏幕大小计算出跟节点的font-size，用于rem样式的适配
     if (this.platform === 'mobile' || this.platform === 'editor') {
       const calcFontsize = () => {
-        let { width } = document.documentElement.getBoundingClientRect();
-        width = Math.min(800, width);
+        const { width } = document.documentElement.getBoundingClientRect();
         const fontSize = width / (this.designWidth / 100);
         document.documentElement.style.fontSize = `${fontSize}px`;
       };

--- a/playground/src/components/DeviceGroup.vue
+++ b/playground/src/components/DeviceGroup.vue
@@ -49,10 +49,9 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const calcFontsize = (width: number) => {
-      const fontSize = width / 3.75;
       const { iframe } = editorService.get<StageCore>('stage').renderer;
       if (!iframe?.contentWindow) return;
-      iframe.contentWindow.document.documentElement.style.fontSize = `${fontSize}px`;
+      iframe.contentWindow.appInstance.designWidth = width;
     };
 
     const viewerDevice = ref(DeviceType.Phone);

--- a/runtime/react/page/main.tsx
+++ b/runtime/react/page/main.tsx
@@ -50,7 +50,10 @@ const getLocalConfig = (): MApp[] => {
 
 window.magicDSL = [];
 
+const designWidth = document.documentElement.getBoundingClientRect().width;
+
 const app = new Core({
+  designWidth,
   config: ((getUrlParam('localPreview') ? getLocalConfig() : window.magicDSL) || [])[0] || {},
   curPage: getUrlParam('page'),
 });

--- a/runtime/react/playground/main.tsx
+++ b/runtime/react/playground/main.tsx
@@ -29,10 +29,15 @@ import plugins from '../.tmagic/plugin-entry';
 
 import App from './App';
 
+const designWidth = document.documentElement.getBoundingClientRect().width;
+
 const app = new Core({
+  designWidth,
   config: {},
   platform: 'editor',
 });
+
+window.appInstance = app;
 
 let curPageId = '';
 

--- a/runtime/vue2/page/main.ts
+++ b/runtime/vue2/page/main.ts
@@ -30,7 +30,10 @@ import { getLocalConfig } from './utils';
 
 Vue.use(request);
 
+const designWidth = document.documentElement.getBoundingClientRect().width;
+
 const app = new Core({
+  designWidth,
   config: ((getUrlParam('localPreview') ? getLocalConfig() : window.magicDSL) || [])[0] || {},
   curPage: getUrlParam('page'),
 });

--- a/runtime/vue2/playground/App.vue
+++ b/runtime/vue2/playground/App.vue
@@ -26,10 +26,15 @@ export default defineComponent({
       () => root.value?.items?.find((item: MNode) => item.id === curPageId.value) || root.value?.items?.[0],
     );
 
+    const designWidth = document.documentElement.getBoundingClientRect().width;
+
     const app = new Core({
+      designWidth,
       config: root.value,
       platform: 'editor',
     });
+
+    globalThis.appInstance = app;
 
     provide('app', app);
 

--- a/runtime/vue3/page/main.ts
+++ b/runtime/vue3/page/main.ts
@@ -43,7 +43,10 @@ Object.values(plugins).forEach((plugin: any) => {
   magicApp.use(plugin);
 });
 
+const designWidth = document.documentElement.getBoundingClientRect().width;
+
 const app = new Core({
+  designWidth,
   config: ((getUrlParam('localPreview') ? getLocalConfig() : window.magicDSL) || [])[0] || {},
   curPage: getUrlParam('page'),
 });

--- a/runtime/vue3/playground/App.vue
+++ b/runtime/vue3/playground/App.vue
@@ -26,10 +26,14 @@ export default defineComponent({
       () => root.value?.items?.find((item: MNode) => item.id === curPageId.value) || root.value?.items?.[0],
     );
 
+    const designWidth = document.documentElement.getBoundingClientRect().width;
     const app = new Core({
+      designWidth,
       config: root.value,
       platform: 'editor',
     });
+
+    globalThis.appInstance = app;
 
     provide('app', app);
 


### PR DESCRIPTION
1.  原来切换设计类型的时候，只是修改了iframe大小和iframe内根字体大小，但app会根据窗体resize再次计算字体大小，所以会失效。
2. 这里是将playground的app实例暴露到了window，以来修改app实例的designWidth，利用resize事件再计算字体 。 
3. 把iframe窗体大小默认设置到了app的designWidth参数，这样使预览大小正确。