### PR TITLE
docs(docs): sidebar属性示例代码缺少闭合标签

### DIFF
--- a/docs/src/api/editor/editor.md
+++ b/docs/src/api/editor/editor.md
@@ -123,6 +123,7 @@ import ModListPanel from '../components/sidebars/ModListPanel.vue';
       component: ModListPanel,
       text: '模块',
     },
+  ]
 }
 ```
 


### PR DESCRIPTION
sidebar属性示例代码块缺少「 ] 」