### PR TITLE
fix: typos 修复错别字导致的bug

### DIFF
--- a/packages/design/src/Autocomplete.vue
+++ b/packages/design/src/Autocomplete.vue
@@ -8,8 +8,8 @@
     @select="selectHandler"
     @update:modelValue="updateModelValue"
   >
-    <template #defalut="{ item }" v-if="$slots.defalut">
-      <slot name="defalut" :item="item"></slot>
+    <template #default="{ item }" v-if="$slots.default">
+      <slot name="default" :item="item"></slot>
     </template>
     <template #prepend v-if="$slots.prepend">
       <slot name="prepend"></slot>


### PR DESCRIPTION
Fix typos 修复错别字导致的bug

packages/design/src/Autocomplete.vue