### PR TITLE
fixed update page node  error

### DIFF
--- a/runtime/react/playground/main.tsx
+++ b/runtime/react/playground/main.tsx
@@ -113,8 +113,9 @@ const operations = {
     updateConfig(root);
   },
 
-  update({ config, root }: UpdateData) {
-    replaceChildNode(app.dataSourceManager?.compiledNode(config, undefined, true) || config, root.items);
+  update({ config, root, parentId}: UpdateData) {
+    const newNode = app.dataSourceManager?.compiledNode(config, undefined, true) || config;
+		replaceChildNode(newNode, [root], parentId);
     updateConfig(cloneDeep(root));
   },
 


### PR DESCRIPTION
react-runtime， 修改page级别的属性，会提示找不到父节点错误， 对比vue3的代码， update函数更新了下