### PR TITLE
docs: select选择器远程选项文档补充

### DIFF
--- a/docs/form-config/fields/select.md
+++ b/docs/form-config/fields/select.md
@@ -162,6 +162,15 @@
   </template>
 </demo-block>
 
+同时在 `src/main.ts` 中需要自定义实现请求
+```typescript 
+app.use(MagicForm, {
+      request: async (options: any) =>  {
+           // 自定义请求实现
+      },
+});
+```
+
 :::tip
 如果 Select 的绑定值为对象类型，请务必指定 valueKey 作为它的唯一性标识。
 :::


### PR DESCRIPTION
在使用select组件开启 remote 时，控制台出现报错 “requestFuc is not a function"的问题，调试后发现开启remote后，需要自定义自定义请求实现，文档并未说明，所以对select组件的remote部分进行补充。