### PR TITLE
修复拖拽调整页面顺序

### DIFF
--- a/packages/editor/src/layouts/page-bar/PageBarScrollContainer.vue
+++ b/packages/editor/src/layouts/page-bar/PageBarScrollContainer.vue
@@ -137,7 +137,7 @@ watch(
         let beforeDragList: Id[] = [];
         const options = {
           ...{
-            dataIdAttr: 'page-id', // 获取排序后的数据
+            dataIdAttr: 'data-page-id', // 获取排序后的数据
             onStart: async (event: SortableEvent) => {
               if (typeof props.pageBarSortOptions?.beforeStart === 'function') {
                 await props.pageBarSortOptions.beforeStart(event, sortable);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -279,6 +279,9 @@ export const getDepNodeIds = (dataSourceDeps: DataSourceDeps = {}) =>
  * @param parentId 父节点 id
  */
 export const replaceChildNode = (newNode: MNode, data?: MNode[], parentId?: Id) => {
+  if(newNode.id==="1"){
+    return;
+  }
   const path = getNodePath(newNode.id, data);
   const node = path.pop();
   let parent = path.pop();


### PR DESCRIPTION
修复由于页面自定义属性变更，Sortable配置中dataIdAttr有误导致拖拽页面调整排序后，点击源码或保存按钮后无效的情况