### PR TITLE
fix(stage): 修复隐藏标尺后再次显示标尺无效

### DIFF
--- a/packages/stage/src/Rule.ts
+++ b/packages/stage/src/Rule.ts
@@ -124,6 +124,7 @@ export default class Rule extends EventEmitter {
     this.hGuides?.off('changeGuides', this.hGuidesChangeGuidesHandler);
     this.vGuides?.off('changeGuides', this.vGuidesChangeGuidesHandler);
     this.containerResizeObserver?.disconnect();
+    this.container = undefined;
     this.removeAllListeners();
   }
 
@@ -137,7 +138,6 @@ export default class Rule extends EventEmitter {
 
     this.hGuides = undefined;
     this.vGuides = undefined;
-    this.container = undefined;
   }
 
   private getGuidesStyle = (type: GuidesType) => ({


### PR DESCRIPTION
## 问题描述

在编辑器顶部栏先点击「隐藏标尺」，再点击「显示标尺」时，标尺无法正常恢复显示。

## 原因说明

`showRule(true)` 为修复隐藏期间画布尺寸变化导致的标尺变形，会先调用 `destroyGuides()` 再 `createGuides()` 重建标尺。

但实现中 `destroyGuides()` 末尾将 `this.container` 置为 `undefined`。而 `createGuides()` 在开头存在：

```ts
if (!this.container) {
  return;
}
```

因此再次显示时挂载节点引用已丢失，`createGuides()` 直接返回 `undefined`，横向/纵向标尺实例无法重建，表现为标尺不出现。

## 修改说明

- **`destroyGuides()`**：仅销毁 Guides 实例并清理对应 DOM，**不再**清空 `this.container`，以便同一次 `Rule` 生命周期内 `showRule(true)` 仍能向同一容器重新挂载标尺。
- **`destroy()`**：在整实例销毁时**再**将 `this.container = undefined`，与 `ResizeObserver` 断开等行为保持一致。

fix #669
