### PR TITLE
fix(form): 修复表格全屏编辑时下拉选项被遮罩遮挡

### DIFF
--- a/packages/form/src/table/Table.vue
+++ b/packages/form/src/table/Table.vue
@@ -1,11 +1,6 @@
 <template>
   <teleport to="body" :disabled="!isFullscreen">
-    <div
-      v-bind="$attrs"
-      class="m-fields-table-wrap"
-      :class="{ fixed: isFullscreen }"
-      :style="isFullscreen ? `z-index: ${nextZIndex()}` : ''"
-    >
+    <div v-bind="$attrs" class="m-fields-table-wrap" :class="{ fixed: isFullscreen }" :style="fullscreenZIndexStyle">
       <div class="m-fields-table" :class="{ 'm-fields-table-item-extra': config.itemExtra }">
         <span v-if="config.extra" style="color: rgba(0, 0, 0, 0.45)" v-html="config.extra"></span>
         <TMagicTooltip
@@ -96,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, useTemplateRef } from 'vue';
+import { computed, ref, useTemplateRef, watch } from 'vue';
 import { FullScreen, Grid, Plus } from '@element-plus/icons-vue';
 
 import { TMagicButton, TMagicPagination, TMagicTable, TMagicTooltip, TMagicUpload, useZIndex } from '@tmagic/design';
@@ -137,6 +132,11 @@ const { pageSize, currentPage, paginationData, handleSizeChange, handleCurrentCh
 );
 
 const { nextZIndex } = useZIndex();
+/** 全屏层 z-index：仅在进入全屏时取一次 nextZIndex，避免每次重渲染累加后盖住 append 到 body 的下拉层 */
+const fullscreenZIndex = ref<number | null>(null);
+const fullscreenZIndexStyle = computed(() =>
+  fullscreenZIndex.value != null ? `z-index: ${fullscreenZIndex.value}` : '',
+);
 const updateKey = ref(1);
 
 const { addable, newHandler } = useAdd(props, emit);
@@ -178,6 +178,15 @@ const sortChangeHandler = (sortOptions: SortProp) => {
   const modelName = props.name || props.config.name || '';
   sortChange(props.model[modelName], sortOptions);
 };
+
+// 监听全屏状态，仅在进入全屏时取一次 nextZIndex，避免每次重渲染累加后盖住 append 到 body 的下拉层
+watch(isFullscreen, (on) => {
+  if (on) {
+    fullscreenZIndex.value = nextZIndex();
+  } else {
+    fullscreenZIndex.value = null;
+  }
+});
 
 defineExpose({
   toggleRowSelection,


### PR DESCRIPTION
## 问题描述

在表单表格（`MFormTable`）开启**全屏编辑**后，若行内为 **下拉框（Select）** 等依赖浮层的控件，展开选项时，选项会被全屏半透明遮罩挡住，无法正常点选。

## 原因说明

全屏时外层容器使用了：

```vue
:style="isFullscreen ? `z-index: ${nextZIndex()}` : ''"
```

`nextZIndex()` 写在模板表达式中，在**全屏开启期间**，组件每次**重新渲染**（如输入、增删行、表格数据更新等）都会再次执行，导致全局 `z-index` 不断累加，全屏层最终可能高于下拉浮层（如 Element Plus 默认约 2000），从而遮挡选项。

## 修改说明

- 使用 `ref` 保存进入全屏时**只计算一次**的 `z-index`。
- 通过 `watch(isFullscreen)`：进入全屏时调用 `nextZIndex()` 并赋值，退出全屏时清空。
- 模板中 `:style` 改为绑定 `computed`，仅使用上述稳定值，避免在渲染路径中重复产生副作用。

fix: #672 
