### PR TITLE
feat(leafer-components): M0+M1 基础包 + 10 个内置 shape

### DIFF
--- a/docs/research/implementation-tasks.md
+++ b/docs/research/implementation-tasks.md
@@ -1,0 +1,745 @@
+# leafer 渲染改造 — 完整任务清单
+
+> 把 editor 端从 iframe + StageMask 改成 leafer-ui 直渲染。runtime 完全不动。
+> 关联调研：[multi-page-infinite-canvas.md](./multi-page-infinite-canvas.md) / [leafer-renderer-migration.md](./leafer-renderer-migration.md)
+> 负责人：roymondchen | 协作：Mavis | 启动：2026-07-31
+
+---
+
+## 0. 总览
+
+**核心包**：`leafer-components/`（新增，跟 `vue-components/` `react-components/` 并列同级，仅 editor 用）
+
+**核心 API 改动**：
+- editor 端：删 Magic API 跨边界调用，新增 `editor.registerShape(type, shapeFn)`
+- runtime 端：**零改动**
+- 业务方接入：1 个新组件 = 3 份实现（vue-component + react-component + leafer-component）
+
+**总工作量**：7 个里程碑（M0-M6），~14 周（1 个前端全职），~50 个原子任务
+
+**总文件变更**：~20 个新增/大改，~5 个删除
+
+---
+
+## 1. 里程碑时间线
+
+| 里程碑 | 主题 | 周 | 关键交付 |
+|---|---|---|---|
+| **M0** | Foundation | 0.5 | shape builder utils + leafer-components 包骨架 + editor `registerShape` API |
+| **M1** | Built-in shapes | 0.5 | 10 个内置 type 全部可渲染（5 完整 + 5 占位） |
+| **M2** | LeaferRender core | 2-3 | LeaferRender 类 + DSL diff + StageCore 路由 + editor service 接入 |
+| **M3** | Editor 整合 | 2-3 | renderer 切换可用 + Magic API 删 + renderer prop 增量 + playground 跑通 |
+| **M4** | 高级交互 | 2-3 | leafer Editor 替代 moveable + 选区/多选/辅助线/历史栈 |
+| **M5** | 多 page 无限画布 | 1-2 | 多 page frame 挂载 + active 切换 + fit-to-all |
+| **M6** | 删老代码 | 1-2 | StageMask/ActionManager/StageDragResize/ScrollViewer/Magic API 全删 |
+
+---
+
+## 2. M0 — Foundation
+
+### T0.1 shape builder utils
+
+**文件**：`leafer-components/src/utils.ts`（新增）
+
+**内容**：
+
+- `export type ShapeFn = (config: MComponent, ctx: ShapeContext) => IUI | { node: IUI; children?: MNode[] } | null`
+- `export const parsePx: (v: any) => number | undefined`
+- `export const parseShadow: (cssBoxShadow?: string) => LeaferShadow | undefined`
+- `export const parseGradient: (cssGradient: string) => LeaferGradient | undefined`
+- `export const parseFontFamily: (v?: string) => string | undefined`
+- `export const buildRectShape: (config: MComponent) => Rect`（占位用）
+- `export const buildTextShape: (config: MComponent & { text?: string }) => Text`（占位用）
+
+**关键设计**：
+- `parseShadow` 处理 `0 2px 8px rgba(0,0,0,0.15)` / `inset` / 多阴影三种 case
+- `parseGradient` 支持 `linear-gradient` / `radial-gradient` / `conic-gradient` 字符串
+- 所有工具函数纯函数，便于单测
+
+**验收**：
+- [ ] `leafer-components/src/utils.ts` 存在
+- [ ] `pnpm test leafer-components` 5 个 parse 函数单测全过
+- [ ] 覆盖率 ≥ 85%（项目约定）
+
+### T0.2 leafer-components 包骨架
+
+**文件**：`leafer-components/package.json`（新增）
+
+**内容**：
+
+```json
+{
+  "name": "@leafer-components",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "peerDependencies": {
+    "leafer-ui": "^2.0.0",
+    "@tmagic/schema": "*",
+    "@tmagic/stage": "*"
+  },
+  "devDependencies": {
+    "leafer-ui": "*",
+    "@tmagic/schema": "*",
+    "@tmagic/stage": "*"
+  }
+}
+```
+
+**关联**：`pnpm-workspace.yaml` 添加 `leafer-components` 路径
+
+**验收**：
+- [ ] `leafer-components/package.json` 存在
+- [ ] `pnpm install` 不报错
+- [ ] 业务方可 `import buttonShape from '@leafer-components/button'`
+
+### T0.3 editor `registerShape` API
+
+**文件**：`packages/stage/src/LeaferShapeRegistry.ts`（新增）
+
+**内容**：
+
+```ts
+import type { ShapeFn } from '@leafer-components/utils'  // 跟 leafer-components 共用 type
+
+export class LeaferShapeRegistry {
+  private shapes: Map<string, ShapeFn> = new Map()
+  register(type: string, shape: ShapeFn) { this.shapes.set(type, shape) }
+  get(type: string): ShapeFn | undefined { return this.shapes.get(type) }
+  has(type: string): boolean { return this.shapes.has(type) }
+  list(): string[] { return Array.from(this.shapes.keys()) }
+}
+```
+
+**文件**：`packages/stage/src/index.ts`（导出）
+
+**验收**：
+- [ ] `LeaferShapeRegistry` 类可注册 / 查 / 列
+- [ ] 导出在 `@tmagic/stage` 主入口
+- [ ] 单测覆盖 register/get/has/list
+
+---
+
+## 3. M1 — Built-in shapes
+
+### T1.1 `text` shape
+
+**文件**：`leafer-components/text/src/index.ts`（新增）
+
+**内容**：
+
+```ts
+import { Text } from 'leafer-ui'
+import { parsePx, type ShapeFn } from '../../utils'
+
+const shape: ShapeFn = (config) => {
+  const c = config as MComponent & { text?: string }
+  return new Text({
+    text: c.text ?? '',
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: parsePx(c.style?.width),
+    height: parsePx(c.style?.height),
+    fill: c.style?.color,
+    fontSize: parsePx(c.style?.fontSize) ?? 14,
+    fontFamily: c.style?.fontFamily,
+    fontWeight: c.style?.fontWeight,
+    textAlign: c.style?.textAlign ?? 'left',
+  })
+}
+
+export default shape
+```
+
+**验收**：playground 加一个 `text` 节点，画布显示文字
+
+### T1.2 `button` shape
+
+**文件**：`leafer-components/button/src/index.ts`（新增）
+
+**内容**：Group[Rect + Text]，15 行（见调研文档 §3 改造 2 完整示例）
+
+**验收**：playground 加一个 `button` 节点，画布显示带底色 + 文字的圆角矩形
+
+### T1.3 `img` shape
+
+**文件**：`leafer-components/img/src/index.ts`（新增）
+
+**内容**：leafer `Image` 节点 + `url: config.url`
+
+**验收**：playground 加一个 `img` 节点，画布显示图片
+
+### T1.4 `container` shape
+
+**文件**：`leafer-components/container/src/index.ts`（新增）
+
+**内容**：leafer `Frame` 节点 + children 递归（ctx.children = config.items）
+
+**验收**：嵌套 container 渲染正确
+
+### T1.5 `overlay` shape
+
+**文件**：`leafer-components/overlay/src/index.ts`（新增）
+
+**内容**：跟 container 几乎一致（都是 Group 容器），可后续区分
+
+**验收**：overlay 容器渲染正确
+
+### T1.6 `page` shape
+
+**文件**：`leafer-components/page/src/index.ts`（新增）
+
+**内容**：leafer `Frame` 节点 + 全屏 `width/height` + children
+
+**验收**：page 根容器渲染正确
+
+### T1.7 `qrcode` placeholder
+
+**文件**：`leafer-components/qrcode/src/index.ts`（新增）
+
+**内容**：buildRectShape 占位，注释说明「runtime 用 qrcode 库，editor 暂时占位」
+
+**验收**：qrcode 节点渲染为浅灰矩形
+
+### T1.8 `page-fragment-container` placeholder
+
+**文件**：`leafer-components/page-fragment-container/src/index.ts`（新增）
+
+**内容**：buildRectShape 占位，注释说明「跟跨页引用有关，业务方可在 runtime 预览看真实效果」
+
+### T1.9 `iterator-container` placeholder
+
+**文件**：`leafer-components/iterator-container/src/index.ts`（新增）
+
+**内容**：buildRectShape 占位
+
+### T1.10 `page-fragment` placeholder
+
+**文件**：`leafer-components/page-fragment/src/index.ts`（新增）
+
+**内容**：buildRectShape 占位
+
+### T1.11 统一入口
+
+**文件**：`leafer-components/src/index.ts`（新增）
+
+**内容**：
+
+```ts
+// AUTO-GENERATED-style: 手动维护,新增 type 时记得加一行
+export { default as button } from '../button/src'
+export { default as text } from '../text/src'
+// ... 10 行
+```
+
+**验收**：`import * as shapes from '@leafer-components'` 拿到 10 个 shape
+
+---
+
+## 4. M2 — LeaferRender core
+
+### T2.1 Render interface 抽象
+
+**文件**：`packages/stage/src/types.ts`（改）
+
+**内容**：从 StageRender 抽 `Render` interface：
+
+```ts
+export interface Render {
+  mount(el: HTMLDivElement): Promise<void>
+  setRoot(root: MApp, pageId?: Id): Promise<void>
+  update(data: UpdateData): Promise<void>
+  add(data: UpdateData): Promise<void>
+  remove(data: RemoveData): Promise<void>
+  select(ids: Id[]): Promise<void>
+  setZoom(zoom: number): void
+  destroy(): void
+  on<E extends keyof RenderEvents>(event: E, listener: (...args: any[]) => void): this
+  emit<E extends keyof RenderEvents>(event: E, ...args: any[]): boolean
+}
+```
+
+**验收**：StageRender / LeaferRender 都实现这个 interface
+
+### T2.2 LeaferRender 类
+
+**文件**：`packages/stage/src/LeaferRender.ts`（新增，~250 行）
+
+**内容**：
+- 构造时 `new Leafer({ view, fill: '#f5f5f5' })`
+- `mount` 创建 leafer 实例 + page frame 根 group
+- `setRoot` 全量 diff（先清空再重建，**P0 阶段**够用，P1 优化增量 diff）
+- `update` / `add` / `remove` 单节点 patch
+- `select` 设置 leafer 节点的 `selected` 状态
+- `setZoom` 调 `leafer.scaleOfWorld(origin, factor)`
+- 内部维护 `nodeMap: Map<Id, IUI>` 用于反查
+- 集成 `@leafer-components/*` 调对应 shape 函数
+
+**关键设计**：
+- 全量 `setRoot` 用 `leafer.tree.destroy()` 清空 → 重建（**P0 阶段**接受）
+- 增量 `update` / `add` / `remove` 用 `nodeMap` 反查，再走 `leafer.add/remove`
+- 抛错用 `leafer.sky` 层的 toast（M2 阶段先 console.error）
+
+**验收**：
+- [ ] LeaferRender 类实现 Render interface
+- [ ] `mount` 成功创建 canvas
+- [ ] `setRoot` 渲染 8 个内置 type
+- [ ] `add` / `update` / `remove` 局部更新正常
+
+### T2.3 DSL diff 算法
+
+**文件**：`packages/stage/src/LeaferRender.ts` 内部 `diffAndPatch` 函数
+
+**内容**：
+- 比对 `oldMap: Map<Id, IUI>` 和 `newMap: Map<Id, IUI>`（按 DSL 全量构建）
+- 找出 add / update / remove 三类 diff
+- 按需调 leafer 的 add/remove/setAttrs
+
+**P0 阶段**简化：只做 full setRoot，diff 留到 P1
+
+**验收**：
+- [ ] T2.2 的 setRoot 调用清晰
+- [ ] 二次 setRoot 不抖动（leafer scene 复用）
+
+### T2.4 StageCore 路由
+
+**文件**：`packages/stage/src/StageCore.ts`（改）
+
+**内容**：
+- 构造时根据 `config.renderer === 'leafer'` 选 LeaferRender
+- 老的 `config.runtimeUrl / config.render` 路径走 StageRender
+- 内部统一调 `this.renderer.xxx()`，对调用方透明
+
+**验收**：
+- [ ] `renderer: 'iframe'` 走 StageRender（老逻辑）
+- [ ] `renderer: 'leafer'` 走 LeaferRender（新逻辑）
+- [ ] 切换不报错，事件正常 emit
+
+### T2.5 editor service 接入
+
+**文件**：`packages/editor/src/services/editor.ts`（改）
+
+**内容**：
+- 删所有 `this.get('stage')?.renderer?.runtime?.getApp?.()?.page?.emit('editor:select', ...)` 调用（line 313-325）
+- 删所有 `runtime?.updatePageId?.(page.id)` 调用（line 243, 378, 419）
+- 删所有 `stage?.add/update/remove` 通过 runtime 的链路，改为直接 `stage.add/update/remove`（走 Render interface）
+- 自动 import leafer-components 全部 shape，在 initService 时 register
+
+**验收**：
+- [ ] `grep -r "runtime?\." packages/editor/src` 结果为 0
+- [ ] 拖入组件在 leafer 画布上立即出现（无延迟）
+- [ ] 选区高亮正常
+
+### T2.6 editor service 启动时注册 shape
+
+**文件**：`packages/editor/src/initService.ts`（改）
+
+**内容**：
+
+```ts
+import * as leaferComponents from '@leafer-components'
+
+// 在 initServiceState 之后:
+for (const [type, shape] of Object.entries(leaferComponents)) {
+  stageRenderer.registerShape(type, shape)
+}
+```
+
+**验收**：
+- [ ] editor 启动时自动注册 10 个 shape
+- [ ] 业务方零感知
+
+---
+
+## 5. M3 — Editor 整合
+
+### T3.1 renderer 切换可用
+
+> **修订**：原计划"新增 PreviewPanel.vue"——错的。主画布的 `MagicStage`（`packages/editor/src/layouts/workspace/viewer/Stage.vue:6`）就是 runtime iframe 本身，已经承载了"runtime 预览"职责。切到 leafer 路径后，业务方想看 Vue/React runtime 渲染，**直接 `renderer: 'iframe'` 切回去**就行，不需要新增组件。
+> 
+> 真正要做的是确保 renderer 切换工作正常：
+> - 业务方能切 `renderer: 'iframe'` 看到 Vue/React runtime（走老的 StageRender）
+> - 业务方能切 `renderer: 'leafer'` 看到 leafer 渲染
+> - 切换不重载整页，只重挂载 stage
+> - 默认 renderer 改成 `'leafer'`，旧业务方切到 `'iframe'` 立即可用
+> 
+> 如果以后要加 side-by-side 分屏预览，那是 v2 增强，不在 M3 必做范围。
+
+**文件**：
+- `packages/stage/src/StageCore.ts`（确保 `config.renderer` 路由正确）
+- `packages/editor/src/services/editor.ts`（确保 `stage` 切换时正确重建）
+
+**验收**：
+- [ ] `renderer: 'iframe'` 走 StageRender，主画布显示 Vue/React 组件
+- [ ] `renderer: 'leafer'` 走 LeaferRender，主画布显示 leafer 渲染
+- [ ] 切换不报错，editor 状态保留（DSL / 选区 / 历史栈不丢）
+
+### T3.2 删 Magic API editor 端调用
+
+**文件**：
+- `packages/editor/src/services/editor.ts`（删 line 313-325 等 `runtime?.`）
+- `packages/editor/src/initService.ts`（删 `runtime?.updatePageId?.()`）
+
+**验收**：
+- [ ] `grep "runtime?." packages/editor/src/` 结果为 0
+- [ ] runtime 那侧 `use-editor-dsl.ts` **保留不动**
+
+### T3.3 editor props 增量（不改名）
+
+> **修订**：原计划"把 `runtimeUrl / render / renderType` 改成 `preview*`"——错的。`runtimeUrl` 这个 prop 描述的是"runtime 入口 URL"，跟 runtime 是主画布还是预览无关。改名是 breaking change，徒增迁移成本。`renderer: 'iframe' | 'leafer'` 这个新 prop 才真正描述了主画布渲染源的新行为。`runtimeUrl / render / renderType` 三个 prop **不动**。
+
+**文件**：`packages/editor/src/editorProps.ts`（改）
+
+**内容**：
+- 保留 `runtimeUrl / render / renderType` 三个 prop 不动
+- 新增 `renderer: 'iframe' | 'leafer'`，默认 `'leafer'`
+- `StageCore` 根据 `config.renderer` 选 StageRender / LeaferRender
+
+**验收**：
+- [ ] 旧 props 全部不改动
+- [ ] 业务方接入零迁移成本
+- [ ] `renderer` 默认 `'leafer'`，业务方显式 `'iframe'` 走老逻辑
+
+### T3.4 playground 验证
+
+**文件**：`playground/src/main.ts`（改）
+
+**内容**：
+
+```ts
+import * as leaferComponents from '@leafer-components'
+
+// 启动 editor 后,立即注册 leafer shape
+for (const [type, shape] of Object.entries(leaferComponents)) {
+  editor.registerShape(type, shape)
+}
+```
+
+**验收**：
+- [ ] playground 启动后画布显示 8 个内置 type
+- [ ] 拖入 component list 里的组件，画布上能落点
+- [ ] `renderer: 'iframe' \| 'leafer'` 切换工作正常
+
+---
+
+## 6. M4 — 高级交互
+
+### T4.1 leafer Editor 插件接入
+
+**文件**：`packages/stage/src/LeaferRender.ts`（改）
+
+**内容**：
+- 启用 leafer `Editor` 插件（替代 moveable）
+- 监听 `drag` / `resize` / `rotate` 事件
+- 抛到 editor service 更新 DSL
+
+**关键设计**：leafer 事件坐标 → 算 delta → 改 `config.style.top/left/width/height` → 走 editor service.update
+
+**验收**：
+- [ ] 拖动节点位置变化
+- [ ] 拖角改尺寸
+- [ ] 改 style 进历史栈
+
+### T4.2 选区 / 多选
+
+**文件**：`packages/stage/src/LeaferRender.ts`（改）
+
+**内容**：
+- leafer selection events → editorService.select(id) / multiSelect(ids)
+- 框选（leafer 内置）→ 同上
+- 反向：editorService.select(id) → leafer selector 同步
+
+**验收**：
+- [ ] 单选 / 多选 / 框选正常
+- [ ] editorService.select 反向同步到画布
+
+### T4.3 辅助线 / snap
+
+**文件**：`packages/stage/src/LeaferRender.ts`（改）
+
+**内容**：
+- leafer `Editor.snap = true` + `Editor.guide = true`
+- 自定义 snap 规则（只对齐 active page 内节点）
+
+**验收**：
+- [ ] 拖动有辅助线
+- [ ] snap 阈值 4px
+
+### T4.4 撤销 / 重做
+
+**文件**：`packages/editor/src/services/editor.ts`（改）
+
+**内容**：
+- leafer drag 结束后调 `editorService.update()`，自动进 history 栈（现有机制）
+- 撤销 / 重做时反向更新 leafer scene
+
+**验收**：
+- [ ] 改 style 后 Ctrl+Z 撤销
+- [ ] 撤销后画布同步
+
+---
+
+## 7. M5 — 多 page 无限画布
+
+### T5.1 多 page frame 挂载
+
+**文件**：`packages/stage/src/LeaferRender.ts`（改）
+
+**内容**：
+- `setRoot(magicApp)` 遍历 `magicApp.items`，每个 MPage 一个 leafer `Frame`
+- Frame 按 grid 平铺（默认间距 100px）
+- 一次性挂载所有 page，pan/zoom 全览
+
+**验收**：
+- [ ] 同时看到 N 个 page
+- [ ] 缩到 fit-to-all 能看到所有 page
+
+### T5.2 active page 切换
+
+**文件**：`packages/editor/src/services/editor.ts`（改）
+
+**内容**：
+- 新增 `setActivePage(id)` action
+- 改对应 leafer frame 的 `data-active="true|false"`，leafer 端加边框视觉
+- 不再销毁 / 重建 Page 实例（App.allPages 缓存）
+
+**验收**：
+- [ ] 切换 active 立即有视觉反馈
+- [ ] Page 实例不重建
+
+### T5.3 page bar 改跳转
+
+**文件**：`packages/editor/src/layouts/page-bar/PageBar.vue`（改）
+
+**内容**：
+- `switchPage(id)` 调 `editorService.setActivePage(id)` + `leafer.focusToPage(id)`
+- 平移动画过渡
+
+**验收**：
+- [ ] 点击 page tab 平移到对应 page
+- [ ] 切换不进历史栈
+
+### T5.4 fit-to-all 快捷键
+
+**文件**：`packages/stage/src/LeaferRender.ts`（改）
+
+**内容**：
+- 监听 Shift+1 触发 fit-to-all
+- 监听 Z（或 F）触发 fit-to-active
+- 监听 0 触发 100% 缩放
+
+**验收**：
+- [ ] 三个快捷键工作
+- [ ] 平滑过渡动画
+
+---
+
+## 8. M6 — 删老代码
+
+### T6.1 删 StageMask
+
+**文件**：删除 `packages/stage/src/StageMask.ts`
+
+**验收**：
+- [ ] TS 编译通过
+- [ ] `grep "StageMask" packages/` 结果只在 types.ts 注释里
+
+### T6.2 删 StageDragResize / StageMultiDragResize
+
+**文件**：删除 `packages/stage/src/StageDragResize.ts` `StageMultiDragResize.ts`
+
+**验收**：TS 编译通过
+
+### T6.3 删 ActionManager
+
+**文件**：删除 `packages/stage/src/ActionManager.ts`
+
+**验收**：TS 编译通过
+
+### T6.4 删 ScrollViewer
+
+**文件**：删除
+- `packages/editor/src/components/ScrollViewer.vue`
+- `packages/editor/src/utils/scroll-viewer.ts`
+
+**验收**：TS 编译通过
+
+### T6.5 删 Moveable 集成
+
+**文件**：
+- `packages/stage/src/MoveableOptionsManager.ts`
+- `packages/stage/src/MoveableActionsAble.ts`
+
+**验收**：`grep -r "moveable" packages/stage/src/` 移除
+
+### T6.6 删 StageRender 路径
+
+**文件**：
+- `packages/stage/src/StageRender.ts` 标记 deprecated，P6 阶段删
+- editor `renderer: 'iframe'` 路径删
+
+**前置条件**：
+- M0-M5 全部完成
+- 业务方跑稳 1-2 个 minor 版本
+- 灰度 100% 业务方无回滚
+
+**验收**：
+- [ ] StageRender.ts 删除
+- [ ] editorProps `renderer` prop 简化为只剩 `'leafer'`
+
+### T6.7 删 Magic API（runtime 端清理）
+
+**文件**：
+- `runtime/vue-runtime-help/src/hooks/use-editor-dsl.ts`（保留 runtime 那侧，editor 那侧已删）
+- `runtime/react-runtime-help/src/hooks/use-editor-dsl.ts`（同上）
+
+**说明**：runtime 那侧的 Magic API 仍保留，因为 runtime 可能被独立使用（不是 editor 上下文）
+
+**验收**：
+- [ ] editor 端无 `magic?.onRuntimeReady` 调用
+- [ ] runtime 端 Magic API 仍 work
+
+---
+
+## 9. 风险清单
+
+| # | 风险 | 触发阶段 | 缓解 |
+|---|---|---|---|
+| 1 | leafer 选区/拖拽手感跟 moveable 差异 | M4 | 重点打磨 + 灰度对比 |
+| 2 | 中文字体加载时机 | M0 | `document.fonts.ready` + `FontFace` API 提前加载 |
+| 3 | 业务方自定义 type 接入 | M1-M2 | 提供文档 + 示例 + 单元测试 |
+| 4 | DSL 频繁改动 leafer scene 性能 | M2 | 增量 diff + RAF 节流 |
+| 5 | 删 StageRender 时业务方有意外回滚 | M6 | 长灰度 + 强监控 + 快速回滚开关 |
+| 6 | page bar 切换不再是切 DOM 的 UX 差异 | M5 | 视觉对比 + 业务方验证 |
+
+---
+
+## 10. 关键文件路径索引
+
+### 新增
+
+- `leafer-components/package.json`
+- `leafer-components/src/index.ts` + `utils.ts`
+- `leafer-components/<type>/src/index.ts`（10 个 type × 1 文件）
+- `packages/stage/src/LeaferRender.ts`
+- `packages/stage/src/LeaferShapeRegistry.ts`
+
+### 改
+
+- `packages/stage/src/StageCore.ts`（双 renderer 路由）
+- `packages/stage/src/types.ts`（Render interface）
+- `packages/stage/src/index.ts`（导出新增）
+- `packages/editor/src/services/editor.ts`（删 Magic API + 自动注册 shape）
+- `packages/editor/src/initService.ts`（自动注册 shape）
+- `packages/editor/src/editorProps.ts`（props 改名 + 新增 renderer）
+- `packages/editor/src/layouts/page-bar/PageBar.vue`（page 切换改 setActivePage）
+- `playground/src/main.ts`（注册 shape）
+
+### 删（M6 阶段）
+
+- `packages/stage/src/StageMask.ts`
+- `packages/stage/src/StageDragResize.ts`
+- `packages/stage/src/StageMultiDragResize.ts`
+- `packages/stage/src/ActionManager.ts`
+- `packages/stage/src/MoveableOptionsManager.ts`
+- `packages/stage/src/MoveableActionsAble.ts`
+- `packages/stage/src/StageRender.ts`（P6 阶段删）
+- `packages/editor/src/components/ScrollViewer.vue`
+- `packages/editor/src/utils/scroll-viewer.ts`
+
+### 不动
+
+- `runtime/vue-runtime-help/`
+- `runtime/react-runtime-help/`
+- `vue-components/`（业务方按需加）
+- `react-components/`（业务方按需加）
+- `playground/src/pages/`, `playground/src/configs/`（业务方代码零改动）
+
+---
+
+## 11. 整体验证标准
+
+### M0 完成
+
+- [ ] `pnpm test leafer-components` 全过
+- [ ] `registerShape('button', ...)` 在 editor service 里能调
+
+### M1 完成
+
+- [ ] playground 跑起来，10 个内置 type 在画布上都有视觉
+- [ ] 每个 type 的 `.shape.ts` 文件 ≤ 30 行
+
+### M2 完成
+
+- [ ] 拖入 component list 里的组件，leafer 画布立即出现
+- [ ] 选区高亮正常
+- [ ] 单测覆盖 ≥ 85%
+
+### M3 完成
+
+- [ ] `renderer: 'iframe' | 'leafer'` 切换可用，业务方零迁移成本
+- [ ] editor 端无 `runtime?.` 调用（`grep` 验证）
+- [ ] `runtimeUrl / render / renderType` 三个 prop 保持不变（不破现有业务方接入）
+
+### M4 完成
+
+- [ ] 拖拽 / 改尺寸 / 旋转 流畅
+- [ ] 多选 / 框选 / 辅助线 / snap 正常
+- [ ] 撤销 / 重做 正常
+
+### M5 完成
+
+- [ ] 同时渲染 N 个 page
+- [ ] fit-to-all 看到所有
+- [ ] fit-to-active 居中
+- [ ] 切换 active 立即视觉反馈
+
+### M6 完成
+
+- [ ] StageMask / ActionManager / StageDragResize / ScrollViewer / StageRender 全部删除
+- [ ] `renderer: 'leafer'` 唯一路径
+- [ ] TS 编译通过
+- [ ] 业务方跑 1-2 个 minor 版本无回滚
+
+---
+
+## 12. 关键决策回顾
+
+- **leafer-components 仅 editor 用**（不是 runtime 替代品）
+- **runtime 完全不动**（vue-components / react-components 保持原样）
+- **shape 是手写**（不搞 codegen，每个 type 一个文件 5-30 行）
+- **Magic API 删 editor 端调用，runtime 端保留**（runtime 可能被独立用）
+- **P0-P5 双 renderer 平行运行**（`renderer: 'iframe' | 'leafer'` 切换），P6 删 `iframe` 路径
+- **Page 实例不销毁**（App.allPages LRU 缓存，多 page 无限画布顺手做）
+- **改造前先查现状**（见 §12.1）
+
+### 12.1 改造前先查现状（反思记录）
+
+调研时两次连续犯错，列下来提醒后续：
+
+1. **T3.1 提"新增 PreviewPanel.vue"**：实际 `MagicStage`（`packages/editor/src/layouts/workspace/viewer/Stage.vue:6`）就是主画布 iframe 本身，runtime 预览职责它已经承担了。切到 leafer 后，业务方用 `renderer: 'iframe'` 切回去就能看 runtime，根本不需要新组件。
+2. **T3.3 提"runtimeUrl → previewRuntimeUrl"**：`runtimeUrl` 这个 prop 名字规范且描述准确（"runtime 入口 URL"），跟 runtime 是主画布还是预览无关。改名是 breaking change 且徒增迁移成本。真正要加的是 `renderer: 'iframe' \| 'leafer'` 这个新 prop。
+
+**教训**：做改造类任务前，**先 `grep` 关键概念**（已有组件 / prop / service / 类型），列出"现有机制"再提"新增/重命名"。
+
+- 接到改造任务，第一动作应该是 `grep` + 列出现状，不是 `write` + 提方案
+- 优先"加开关"（`renderer: 'a' | 'b'`、`useXxx()`），少做"换名字"
+- 反思时如果发现自己两次都倾向"加法"（新增/重命名），停下来问自己"是不是没看现状"
+
+---
+
+## 13. 进度追踪
+
+每个任务的 `Status: pending | in_progress | completed` 由执行者维护。
+
+| 任务 | 状态 | 负责人 | 完成时间 |
+|---|---|---|---|
+| T0.1 shape builder utils | pending | | |
+| T0.2 leafer-components 包骨架 | pending | | |
+| T0.3 editor `registerShape` API | pending | | |
+| T1.1 text shape | pending | | |
+| T1.2 button shape | pending | | |
+| ... | | | |
+| T6.7 删 Magic API | pending | | |
+
+（详细 50 个任务的表格在 issue tracker 里维护，doc 这份只列里程碑进度）

--- a/docs/research/leafer-renderer-migration.md
+++ b/docs/research/leafer-renderer-migration.md
@@ -1,0 +1,636 @@
+# 调研：把 editor 端从 iframe + StageMask 改成 leafer 渲染
+
+> 目标：editor 端不再用 iframe 跑 Vue/React runtime，改为直接用 leafer-ui 渲染 DSL；runtime 保持不变，作为独立的"运行时预览"面板存在。
+> 关联：[多 page 无限画布调研](./multi-page-infinite-canvas.md) — leafer 路径下大量步骤变成"自然结果"，本调研替代其中 StageRender / StageMask / ActionManager / ScrollViewer 相关改动。
+
+---
+
+## 0. 一句话总结
+
+**核心变化**：editor 端从「跨 iframe 通信改 DOM」改成「DSL → leafer 场景树 → canvas」。runtime 那套 Vue/React/iframe 完全保留，挪到独立预览面板。
+
+**4 个关键改造点**：
+
+1. **StageRender → LeaferRender** — `packages/stage/src/StageRender.ts:248-275` 的 iframe 创建/挂载/同源检测/srcdoc fallback 整段替换为 leafer 场景树
+2. **MComponent → leafer 视觉映射** — 每个组件 type 注册一个 shape 函数，built-in 类型（container/text/image/button）走默认映射，自定义类型由业务方 `editor.registerShape` 提供
+3. **editor ↔ canvas 通信直连** — `packages/stage/src/types.ts:249` 的 Magic API（`updatePageId / add / update / remove / select`）和 `packages/editor/src/services/editor.ts` 里所有 `runtime?.xxx?.()` 调用全部删除；editor 直接 mutate DSL → leafer scene diff 重画
+4. **StageMask / ActionManager / StageDragResize / ScrollViewer 整包瘦身** — `packages/stage/src/StageMask.ts:358` `StageDragResize.ts` `ActionManager.ts` `util/scroll-viewer.ts` 这些都是为了「跨 iframe 操作 DOM」而存在的胶水代码，leafer 自带 viewport / 选区 / 拖拽 / snap / 辅助线
+
+**核心 trade-off**：editor 画布上看到的视觉是 leafer 画的，不是 Vue/React 组件渲染的。两者通过"shape 函数"对齐，但不能保证 100% 像素级一致。需要「运行时预览」面板让业务方看真实效果。
+
+---
+
+## 1. 现状盘点（基于代码）
+
+### 1.1 editor ↔ runtime 跨边界通信
+
+| 概念 | 现状 | 文件 |
+| --- | --- | --- |
+| 渲染容器 | iframe（同源直接 src / 跨域 srcdoc） | `packages/stage/src/StageRender.ts:109-126` |
+| 跨边界 API | `Magic` 接口（`updateRootConfig / updatePageId / add / update / remove / select`） | `runtime/vue-runtime-help/src/hooks/use-editor-dsl.ts:66-90`、`packages/stage/src/types.ts:240-250` |
+| editor 调用 runtime | `editorService` 注入 `runtime` ref + postMessage | `packages/editor/src/services/editor.ts:313-325,432-444` |
+| 选区 / 蒙层 | `StageMask` 覆盖在 iframe 之上，监听 pointer 事件 | `packages/stage/src/StageMask.ts:1-358` |
+| 拖拽 / 缩放 | 集成 `moveable` 库 + 自定义 `StageDragResize / StageMultiDragResize` | `packages/stage/src/StageDragResize.ts:1-?`、`packages/stage/src/StageMultiDragResize.ts:1-?` |
+| 辅助线 / 参考线 | `Rule` + `moveable` 的 guidelines | `packages/stage/src/Rule.ts:1-?` |
+| 滚动 / 缩放 | 自定义 `ScrollViewer`，以 page 尺寸为基准 | `packages/editor/src/components/ScrollViewer.vue:1-131`、`packages/editor/src/utils/scroll-viewer.ts:1-167` |
+| 组件渲染 | 业务方 `app.registerComponent(type, VueComponent)` → 注入到 runtime | `runtime/vue/page/main.ts:53`、`runtime/vue/playground/main.ts:46` |
+
+### 1.2 DSL → 视觉 链路
+
+```
+DSL (MApp) 
+  → App.setConfig()
+  → App.setPage(id)         # 单例，销毁旧的 Page 实例
+  → new Page({config, app}) # 构建 Node 树
+  → runtime App.vue: 
+      <MagicUiPage config={pageConfig} />
+        → useDsl().pageConfig
+        → <Container v-for>
+          → <Button v-for> ← 业务方注册的 Vue 组件
+            → 真实 DOM
+  → editor 通过 iframe.contentWindow.document 看到 DOM
+  → editor 通过 Magic API 反向操控 runtime
+```
+
+**这个链路有 3 个成本**：
+
+1. **跨边界通信成本**：editor 改 style → postMessage → runtime 重新渲染 → 通知 editor。同步变异步，editor 要等 runtime-ready 事件才能选中组件
+2. **iframe 创建成本**：跨域用 srcdoc fallback（`StageRender.ts:113-117`），多一层 fetch HTML 解析
+3. **Mental model 成本**：业务方要懂 2 套生命周期（Vue/React 组件生命周期 + editor service 状态机）
+
+### 1.3 业务方组件实现
+
+`vue-components/` 和 `react-components/` 下每个 type 一个文件，共 8 个内置 type：
+- `page`、`container`、`text`、`button`、`img`、`qrcode`、`overlay`、`page-fragment`、`page-fragment-container`、`iterator-container`
+- 都很简单：`text` 是 `<p v-html>`、`button` 是 `<button>`、`container` 是 `<div v-for>` 渲染子项
+
+参考：`vue-components/button/src/index.vue:1-31`、`vue-components/text/src/index.vue:1-37`、`vue-components/container/src/Container.vue:1-46`
+
+---
+
+## 2. 目标态
+
+### 2.1 架构对比
+
+**当前**：
+
+```
+┌─────────────────────────────────────────────┐
+│  editor (Vue 3)                             │
+│  ┌──────────┐  ┌──────────────────────────┐ │
+│  │ Sidebar  │  │ StageContainer (DOM)     │ │
+│  │ Props    │  │  ├─ StageMask (overlay)  │ │
+│  │ PageBar  │  │  │   ├─ Rule / Drag etc. │ │
+│  └──────────┘  │  │                        │ │
+│                │  └─ <iframe> ←──┐         │ │
+│                │      document   │         │ │
+│                │                  │         │ │
+│                │      ┌───────────┘         │ │
+│                │      │ postMessage          │ │
+│                │      │ Magic API            │ │
+│                │  ┌───┴──────────────┐     │ │
+│                │  │ runtime (Vue/React) │   │ │
+│                │  │  <MagicUiPage>     │   │ │
+│                │  │   <Container>      │   │ │
+│                │  │    <Button>        │   │ │
+│                │  └───────────────────┘     │ │
+│                └──────────────────────────┘ │
+└─────────────────────────────────────────────┘
+```
+
+**目标**：
+
+```
+┌─────────────────────────────────────────────┐
+│  editor (Vue 3)                             │
+│  ┌──────────┐  ┌──────────────────────────┐ │
+│  │ Sidebar  │  │ StageContainer           │ │
+│  │ Props    │  │  └─ <canvas>             │ │
+│  │ PageBar  │  │      └─ leafer scene     │ │
+│  └──────────┘  │          ├─ page frames  │ │
+│                │          ├─ shape trees  │ │
+│                │          └─ selection box │ │
+│                └──────────────────────────┘ │
+│                                              │
+│  ┌──────────────────────────────────────┐  │
+│  │ PreviewPanel (独立 tab / drawer)     │  │
+│  │  └─ <iframe> ← runtime (Vue/React)  │  │
+│  │      保留,只用来"看真实效果"         │  │
+│  └──────────────────────────────────────┘  │
+└─────────────────────────────────────────────┘
+```
+
+### 2.2 数据流对比
+
+**当前**：editor 改 DSL → 算 diff → postMessage → runtime 改 DOM → 通知 editor
+
+**目标**：editor 改 DSL → 算 diff → 直接更新 leafer scene（in-process，同步）
+
+### 2.3 API 增减表
+
+| API | 当前 | 目标 | 备注 |
+|---|---|---|---|
+| `editor.registerShape(type, fn)` | ❌ | ✅ 新增 | leafer shape 注册 |
+| `editor.registerComponent(type, VueComponent)` | ❌ | ⚠️ 移到 runtime | runtime 还需要，editor 不需要 |
+| `app.registerComponent(type, Component)` | ✅ | ✅ 保留 | runtime 用 |
+| `Magic.updatePageId(id)` | ✅ | ❌ 删除 | 改为 `editorService.setActivePage(id)` |
+| `Magic.add/update/remove/select` | ✅ | ❌ 删除 | 改为直接 mutate leafer scene |
+| `Magic.updateRootConfig` | ✅ | ❌ 删除 | 改为 `editorService.setRoot(dsl)` → leafer 全量重画 |
+| `StageRender.setZoom` | ✅ | ❌ 删除 | 改为 `leafer.scaleOfWorld(...)` |
+| `StageMask.setLayout / observe` | ✅ | ❌ 删除 | leafer 自带选区 |
+| `ScrollViewer` | ✅ | ❌ 删除 | leafer 自带 viewport |
+| `editor.renderer: 'iframe' \| 'leafer'` | ❌ | ✅ 新增（P0 阶段） | 平行运行切换 |
+
+---
+
+## 3. 4 个关键改造点（详细）
+
+### 改造 1：StageRender → LeaferRender
+
+**当前**：`StageRender` 创建 iframe → runtime 加载到 iframe → editor 通过 `contentWindow.document` 访问 DOM
+
+**新**：`LeaferRender` 创建 canvas DOM → 构造 `Leafer` 实例 → 监听 DSL 变化，diff leafer scene
+
+```ts
+// packages/stage/src/LearferRender.ts (新增)
+import { Leafer, Rect, Text, Group, Frame, Image } from 'leafer-ui'
+import type { MApp } from '@tmagic/schema'
+import type { Render, Runtime, RenderEvents, UpdateData } from './types'
+
+export default class LeaferRender extends EventEmitter implements Render {
+  public leafer: Leafer | null = null
+  // 维护 MNode.id → leafer UI 的映射，避免每次全量重画
+  private nodeMap: Map<Id, IUI> = new Map()
+  // 注册的 shape 函数
+  private shapeRegistry: Map<string, ShapeFn> = new Map()
+  // 业务方在 setRoot 时可以传 rootWidth/rootHeight 决定画布初始尺寸
+  // 之后用户 pan/zoom
+
+  constructor(config: { zoom?: number; renderer?: 'canvas' | 'webgl' } = {}) {
+    super()
+    this.zoom = config.zoom ?? DEFAULT_ZOOM
+  }
+
+  public registerShape(type: string, fn: ShapeFn) {
+    this.shapeRegistry.set(type, fn)
+  }
+
+  public async setRoot(root: MApp) {
+    if (!this.leafer) return
+    // 全量 / 增量重画：先 diff 旧 scene，再 patch
+    diffAndPatch(this.leafer, this.nodeMap, root, this.shapeRegistry)
+  }
+
+  public async mount(el: HTMLDivElement) {
+    this.leafer = new Leafer({ view: el, fill: '#f5f5f5' })
+    this.leafer.tree.add(Frame.one({ name: 'page-root', fill: '#fff' }))
+  }
+
+  public async update(data: UpdateData) { /* 单节点更新，diff 局部 */ }
+  public async add(data: UpdateData) { /* 增量添加 */ }
+  public async remove(data: RemoveData) { /* 增量删除 */ }
+  public async select(ids: Id[]) { /* leafer 选区高亮 */ }
+
+  // ... 其余接口跟 StageRender 对齐，保持 StageCore 调用方零改动
+}
+```
+
+**关键点**：
+
+- `setRoot` 不要每次全量 clear + 重建，会丢 zoom/pan 状态。要做 diff
+- 业务方在 `app.registerComponent` 之外，新增一个 `editor.registerShape`。两个注册并行存在
+- 老的 `StageRender` 不立即删，作为 P0 阶段 `renderer: 'iframe'` 路径
+
+### 改造 2：MComponent → leafer 视觉映射
+
+**核心问题**：tmagic 的 MComponent 走 Vue/React 渲染，leafer 走 canvas。需要一份"shape 描述"，把 MComponent 翻译成 leafer 节点。
+
+**3 种方案**（推荐度从高到低）：
+
+#### 方案 A：按 type 注册 shape（推荐）
+
+```ts
+// editor 提供
+editor.registerShape('container', (config, ctx) => {
+  const rect = new Rect({
+    x: parsePx(config.style.left) ?? 0,
+    y: parsePx(config.style.top) ?? 0,
+    width: parsePx(config.style.width),
+    height: parsePx(config.style.height),
+    fill: config.style.backgroundColor ?? 'transparent',
+    cornerRadius: parsePx(config.style.borderRadius) ?? 0,
+    shadow: parseShadow(config.style.boxShadow),
+  })
+  rect.name = config.id
+  // children 由递归生成
+  return { node: rect, children: config.items ?? [] }
+})
+
+editor.registerShape('text', (config) => new Text({
+  text: config.text ?? '',
+  x: parsePx(config.style.left),
+  y: parsePx(config.style.top),
+  width: parsePx(config.style.width),
+  height: parsePx(config.style.height),
+  fill: config.style.color,
+  fontSize: parsePx(config.style.fontSize) ?? 14,
+  fontFamily: config.style.fontFamily ?? 'PingFang SC, sans-serif',
+  fontWeight: config.style.fontWeight,
+  textAlign: config.style.textAlign ?? 'left',
+}))
+
+editor.registerShape('image', (config) => new Image({
+  url: config.url,
+  x: parsePx(config.style.left),
+  y: parsePx(config.style.top),
+  width: parsePx(config.style.width),
+  height: parsePx(config.style.height),
+}))
+
+editor.registerShape('button', (config) => {
+  // 按钮是 group：底色矩形 + 文字
+  const group = new Group()
+  group.add(new Rect({
+    width: parsePx(config.style.width),
+    height: parsePx(config.style.height),
+    fill: config.style.backgroundColor ?? '#409EFF',
+    cornerRadius: parsePx(config.style.borderRadius) ?? 4,
+  }))
+  group.add(new Text({
+    text: config.text ?? '',
+    fill: config.style.color ?? '#fff',
+    fontSize: parsePx(config.style.fontSize) ?? 14,
+    textAlign: 'center',
+    verticalAlign: 'middle',
+  }))
+  return { node: group, children: [] }
+})
+
+editor.registerShape('qrcode', (config) => {
+  // QRCode 比较特殊：runtime 端用库生成 canvas
+  // editor 端要么 fallback 到占位，要么提供一个 mock
+  return new Rect({
+    width: parsePx(config.style.width),
+    height: parsePx(config.style.height),
+    fill: '#f0f0f0',
+  })
+})
+```
+
+**优点**：跟现有 `app.registerComponent` 模式对称，业务方接入成本低
+**缺点**：每个组件 type 都要写一份 shape
+
+#### 方案 B：HTML overlay 兜底复杂组件
+
+对于方案 A 画不好的复杂组件（图表、富文本），在 leafer 容器上叠加一个绝对定位的 HTML 元素：
+
+```ts
+function htmlOverlayShape(config, ctx) {
+  // 1. leafer 画一个透明 Rect 占位（用于 hit / 选区）
+  const placeholder = new Rect({
+    x: ..., y: ..., width: ..., height: ...,
+    fill: 'transparent', hitSelf: true,
+  })
+  // 2. editor 单独维护一个 HTML 元素 overlay
+  const html = document.createElement('div')
+  html.style.cssText = `position: absolute; left: ${x}px; top: ${y}px; ...`
+  // html 内部用 Vue 组件渲染（不挂到 app，只读 props 渲染）
+  // 3. shape 返回一个标记，让 editor 把 html 元素关联到 placeholder
+  return { node: placeholder, overlay: { el: html, mount: (app) => app.mount(html) } }
+}
+```
+
+**适用**：业务方自定义复杂组件，或者不想写 shape 时
+**风险**：HTML overlay 跟 leafer 的 pan/zoom 同步要小心，editor 改动 zoom 时 overlay 位置/尺寸要同步
+
+#### 方案 C：纯 style 推断
+
+只用 `MComponent.style` 推 rect/text/image，不读 type。**不推荐**，丢失组件语义，复杂组件完全没法画
+
+**推荐：方案 A 为主 + 方案 B 兜底**
+
+### 改造 3：editor ↔ canvas 直连，删 Magic API
+
+**当前**（跨边界）：
+
+```ts
+// editor 端
+await stage.add({ config, parent, parentId, root })
+// → postMessage → runtime 拿到
+// → runtime 调 app.add(config)
+// → runtime 改 DOM
+// → 通知 editor "added"
+```
+
+**新**（in-process）：
+
+```ts
+// editor 端直接改 DSL + leafer scene
+async add(data: UpdateData) {
+  // 1. 改 DSL（immutable update）
+  // 2. 局部更新 leafer scene
+  const newNode = this.shapeRegistry.get(data.config.type)(data.config, this)
+  this.nodeMap.set(data.config.id, newNode)
+  this.leafer?.add(newNode)
+  this.emit('add', data)
+}
+```
+
+**要删的东西**：
+
+- `packages/stage/src/types.ts:240-250` 的 `Magic` 接口里 `updatePageId / updateRootConfig / add / update / remove / select`
+- `runtime/vue-runtime-help/src/hooks/use-editor-dsl.ts:66-90` 的 `window.magic?.onRuntimeReady` 整套（保留 runtime 那侧，editor 不再调）
+- `runtime/react-runtime-help/src/hooks/use-editor-dsl.ts` 同上
+- `packages/editor/src/services/editor.ts` 所有 `runtime?.updatePageId?.()` / `runtime?.select?.()` / `runtime?.update?.()` / `runtime?.add?.()` / `runtime?.remove?.()` 调用
+- `runtimeUrl` / `customizedRender` / `renderType` props 降级为 `previewRuntimeUrl` / `previewRender` / `previewRenderType`
+
+**保留 runtime 那侧**：runtime 仍可独立使用（业务方无 editor 场景，runtime 仍要工作）
+
+### 改造 4：StageMask / ActionManager / StageDragResize / ScrollViewer 整包瘦身
+
+| 当前 | 替代 |
+|---|---|
+| `packages/stage/src/StageMask.ts` (358 行) | 删。leafer 自带选区高亮（`leafer.selector` / `leafer-editor` 插件） |
+| `packages/stage/src/StageDragResize.ts` + `StageMultiDragResize.ts` | 删。leafer 自带 `Editor` 插件：拖拽 / resize / rotate / multi-select |
+| `packages/stage/src/ActionManager.ts` | 删。leafer 自带 pointer events + selection events |
+| `packages/editor/src/components/ScrollViewer.vue` + `utils/scroll-viewer.ts` (167 行) | 删。leafer 自带 viewport pan/zoom（`leafer.move` / `scaleOfWorld`） |
+| `packages/stage/src/Rule.ts` | 删。leafer 的 `Editor` 插件自带辅助线 |
+| `packages/stage/src/StageFlashHighlight.ts` | 删。leafer `Editor` 自带 hover/flash 高亮 |
+
+**保留的**：
+- `packages/stage/src/StageCore.ts` — 保留，改成 `LeaferRender` 的包装
+- `packages/stage/src/StageRender.ts` — **保留**（P0 阶段用），后期 `renderer: 'leafer'` 稳定后再删
+- `packages/stage/src/MoveableOptionsManager.ts` + `MoveableActionsAble.ts` + `StageHighlight.ts` — 看是否还有用，没用就删
+
+**总体收尾**：leafer 路径下，`packages/stage/src/` 从 16 个文件缩到 4-5 个。
+
+---
+
+## 4. 运行时怎么保留
+
+runtime 完全不动，从"画布渲染源"降级为"预览源"：
+
+**做法 1**（推荐）：编辑器右侧 / 底部加一个"预览" tab / drawer
+- 默认折叠，只在用户点开时挂载 iframe
+- 用户可以选 runtime 设备类型（mobile / tablet / pc）
+- 同步当前编辑的 page（`editorService.state.page`）
+
+**做法 2**：保留 `editor.renderer: 'iframe' \| 'leafer'` 切换开关（双 renderer 平行运行）
+- P0 阶段用，业务方默认 `iframe`，手动切 `leafer` 试新
+- P1-P2 稳定后改默认 `leafer`
+- P3 删 `iframe` 路径
+
+**Preview 面板的代码**：
+```vue
+<!-- packages/editor/src/layouts/preview/PreviewPanel.vue (新增) -->
+<template>
+  <div v-if="open" class="m-editor-preview">
+    <iframe v-if="runtimeUrl" :src="runtimeUrl" :style="deviceStyle" />
+    <component v-else-if="customizedRender" :is="customizedRender" />
+  </div>
+</template>
+```
+
+**保持不变**：
+- `vue-components/` `react-components/` 完全保留
+- `app.registerComponent` API 保留
+- 用户的业务代码零改动
+
+**变更 props**：
+```ts
+// 旧
+{ runtimeUrl, render: customizedRender, renderType }
+// 新（语义更清晰）
+{ previewRuntimeUrl, previewRender, previewRenderType, renderer: 'iframe' | 'leafer' }
+```
+
+`renderer: 'iframe'` 走老逻辑（保留），`renderer: 'leafer'` 走新逻辑。
+
+---
+
+## 5. 跟多 page 无限画布调研的关系
+
+之前那份调研（[multi-page-infinite-canvas.md](./multi-page-infinite-canvas.md)）里很多 Step 现在变成 leafer 自带：
+
+| 之前调研的 Step | leafer 路径下的状态 |
+|---|---|
+| Step 1 数据模型 + store 增量 | **保留**（多 page 切换 active 仍需要） |
+| Step 2 runtime 多 page 渲染 | **简化**：每个 MPage 是一个 leafer Frame，page 之间平铺 |
+| Step 3 Page 实例生命周期 | **保留**（Node 树还是要建） |
+| Step 4 StageMask / 选区 / 辅助线 | **直接删**（leafer 自带） |
+| Step 5 ScrollViewer → CanvasViewer | **直接删**（leafer 自带 viewport） |
+| Step 6 page bar 改 setActivePage | **简化**：leafer frame 加 `data-active` 边框即可 |
+| Step 7 拖入 / 框选只对 active page 生效 | **保留**（逻辑层要做，leafer 只是渲染） |
+| Step 8 缩略图 / page bar 增强 | **保留** |
+| Step 9 page 间连接线（可选） | **保留**（leafer 可以画 SVG overlay） |
+
+**结论**：用 leafer 之后，"多 page 无限画布"是顺手送的，不需要单独搞一套改造。两条路可以合并到一份调研 / 实施计划里。
+
+---
+
+## 6. 可行性验证：圆角 / 阴影 / 渐变 / 字体
+
+> 业务方核心担忧：「leafer 画出来的视觉跟 Vue/React 组件的视觉对不上」。先验 4 个最常见的视觉特性。
+
+### 6.1 结论
+
+**4 项全部原生支持**，leafer-ui 的 API 跟 CSS 风格高度一致。
+
+| 特性 | leafer-ui API | CSS 对应 | 来源 |
+|---|---|---|---|
+| 圆角 | `Rect({ cornerRadius: 8 })` 或 4 角独立 | `border-radius` | 官方对比表 + leafer-design 开源项目 |
+| 外阴影 | `Rect({ shadow: { x, y, blur, color } })` | `box-shadow` | 官方对比表 |
+| 内阴影 | `Rect({ innerShadow: {...} })` | `box-shadow: inset` | 官方对比表 |
+| 多阴影 | `Rect({ shadows: [...] })` | 多个 `box-shadow` | 官方对比表 |
+| 线性渐变 | `Rect({ fill: { type: 'linear', stops, angle } })` | `linear-gradient` | 官方对比表 + leafer-design |
+| 径向渐变 | `Rect({ fill: { type: 'radial', stops } })` | `radial-gradient` | 官方对比表 |
+| 锥形渐变 | `Rect({ fill: { type: 'conic', ... } })` | `conic-gradient` | 官方对比表 |
+| 图片填充 | `Rect({ fill: { type: 'image', url } })` | `background-image` | 官方对比表 |
+| 字体 | `Text({ fontFamily, fontSize, fontWeight, fontStyle, textAlign })` | `font-*` | leafer-x-tooltip-canvas 插件 config |
+| 自定义字体 | CSS `@font-face` / `FontFace` API 加载 → `fontFamily: 'xxx'` 引用 | 浏览器原生 | 浏览器 canvas 2D 渲染走 `document.fonts` |
+| 滤镜 | `Rect({ filter: 'blur(4px)' })` | CSS `filter` | 官方对比表 |
+| 混合模式 | `Rect({ blendMode: 'multiply' })` | CSS `mix-blend-mode` | 官方对比表 |
+| 多 fill 叠层 | `Rect({ fills: [...] })` | 多个 `background-image` | 官方对比表 |
+| 描边 | `Rect({ stroke: { type: 'solid', color }, strokeWidth })` | `border` | 官方对比表 |
+| zoom 无关 | `Rect({ fixedSize: true, fixedShadow: true })` | — | 官方对比表 |
+
+### 6.2 端到端 minimal demo（10 行验证 4 个特性）
+
+```ts
+import { Leafer, Rect, Text } from 'leafer-ui'
+
+// 用一个"按钮"验完 4 个特性：圆角 + 渐变 + 阴影 + 自定义字体
+const leafer = new Leafer({ view: '#canvas', width: 400, height: 200 })
+
+leafer.add(new Rect({
+  x: 100, y: 70, width: 200, height: 60,
+  // ✅ 1. 圆角
+  cornerRadius: 30,
+  // ✅ 2. 渐变（线性）
+  fill: { type: 'linear', stops: [
+    { offset: 0, color: '#32cd79' },
+    { offset: 1, color: '#1e8b4f' },
+  ]},
+  // ✅ 3. 阴影
+  shadow: { x: 0, y: 4, blur: 12, color: 'rgba(0,0,0,0.2)' },
+}))
+
+leafer.add(new Text({
+  x: 200, y: 100,
+  text: '立即购买',
+  // ✅ 4. 自定义字体（系统字体走 fontFamily，中文 web 字体走 @font-face）
+  fontFamily: 'PingFang SC, sans-serif',
+  fontSize: 18,
+  fontWeight: 'bold',
+  fill: '#fff',
+  textAlign: 'center',
+}))
+```
+
+**预期结果**：在 `#canvas` div 上画一个带渐变 + 阴影 + 圆角的绿色按钮，中间是白色加粗"立即购买"文字。中文走系统 PingFang 字体。
+
+### 6.3 注意点
+
+1. **结构化对象 ≠ CSS 字符串**：leafer 不解析 CSS 字符串。`box-shadow: '0 2px 8px rgba(0,0,0,0.15)'` 不会直接生效，要转成 `{x:0, y:2, blur:8, color:'rgba(...)'}`。写个 20 行的 CSS-to-leafer 转换函数搞定。
+
+2. **fill 跟 style 字段重名**：tmagic 的 `MComponent.style.backgroundColor`（CSS 风格）跟 leafer 的 `Rect.fill`（leafer 风格）需要映射：
+
+   ```ts
+   editor.registerShape('container', (config) => new Rect({
+     x: parsePx(config.style.left) ?? 0,
+     y: parsePx(config.style.top) ?? 0,
+     width: parsePx(config.style.width),
+     height: parsePx(config.style.height),
+     fill: config.style.backgroundColor,           // 字段映射
+     cornerRadius: parsePx(config.style.borderRadius),
+     shadow: parseShadow(config.style.boxShadow),  // 字符串 → 对象
+   }))
+   ```
+
+3. **中文字体加载**：用标准 CSS `@font-face` 或 JS `FontFace` API 加载后，leafer 的 `Text` 节点 `fontFamily` 字段直接引用即可：
+   ```ts
+   const font = new FontFace('MyFont', 'url(/fonts/my.woff2)')
+   await font.load()
+   document.fonts.add(font)
+   // 之后 leafer Text 节点 fontFamily: 'MyFont' 直接生效
+   ```
+
+4. **运行时侧对照验证**：业务方担心 editor 跟 runtime 视觉对不上，提供：
+   - 快捷键 `Cmd/Ctrl+P` 打开"运行时预览"面板
+   - 每次 style 变更后 `leafer.export('png')` 一张图，跟 runtime iframe 截图做像素 diff（CI 阶段用）
+
+### 6.4 已经在用 leafer 跑生产的设计器
+
+`leafer-design`（https://github.com/leaferjs/leafer-design）是一个基于 leafer-ui 的开源海报设计器，功能列表直接覆盖我们的需求：
+
+> ✅ 边框描边（纯色、线性渐变、径向渐变、图片）
+> ✅ 填充（纯色、线性渐变、径向渐变、图片）
+> ✅ 文本字体、粗细、大小
+> ✅ 多页面支持
+> ✅ 画布缩放、拖动模式
+
+证明这套 API 已经在"接近 Figma 风格的设计器"上跑过生产。
+
+---
+
+## 7. 落地步骤
+
+| 阶段 | 内容 | 估时 | 风险 |
+|---|---|---|---|
+| **P0 — 平行运行** | 保留 StageRender，新增 LeaferRender + `renderer: 'iframe' \| 'leafer'` prop；leafer 走通 container / text / image / button 4 个 built-in shape；leafer 走通 select / drag / pan / zoom | 3-4 周 | 中：leafer 交互手感要调 |
+| **P1 — shape 注册 API** | 加 `editor.registerShape`，把 P0 的 4 个 built-in 改走注册表；为 `vue-components/*` 每个 type 加对应 shape（一个组件一个 shape） | 2-3 周 | 中：每个组件 shape 写起来 |
+| **P2 — 高级交互** | snap / 辅助线 / 多选 / 框选 / moveable 用 leafer `Editor` 插件替代 | 2-3 周 | 高：交互细节调优 |
+| **P3 — 多 page 无限画布** | 在 leafer 场景里挂 N 个 page frame，pan/zoom 全览；多 page 切换 active | 1-2 周 | 低（顺带的） |
+| **P4 — 删老代码** | StageMask / ActionManager / StageDragResize / Magic API / iframe 通信全部删 | 2 周 | **高**：要保证零回归 |
+
+**总估时 ~10-14 周**，1 个前端全职。
+
+**里程碑**：
+
+- **M1（P0 完成）**：业务方可以 `renderer: 'leafer'` 切到新画布，container/text/image/button 4 个 type 渲染对齐 Vue 组件
+- **M2（P1 完成）**：所有内置 type 都有 shape，业务方的自定义 type 也可以通过 `registerShape` 接进来
+- **M3（P2 完成）**：snap / 辅助线 / 多选 / 框选 / 缩放 / 旋转手感对齐 moveable
+- **M4（P3 完成）**：多 page 同时渲染 + 无限画布 pan/zoom
+- **M5（P4 完成）**：删 `renderer: 'iframe'` 路径，老 iframe / Magic API 全部清理
+
+---
+
+## 8. 关键文件改动清单
+
+| 文件 | 改动类型 | 说明 |
+|---|---|---|
+| `packages/stage/src/LearferRender.ts` | 新增 | leafer 渲染器 |
+| `packages/stage/src/LeaferShapeRegistry.ts` | 新增 | shape 注册中心 |
+| `packages/stage/src/LeaferViewport.ts` | 新增 | pan/zoom 控制器（包一层 leafer.move/scaleOfWorld） |
+| `packages/stage/src/LeaferSelection.ts` | 新增 | 选区事件桥（leafer selection → editorService.select） |
+| `packages/stage/src/types.ts` | 加接口 | `Render` interface 跟 StageRender 对齐，editor service 调用方零改动 |
+| `packages/stage/src/StageCore.ts` | 改 | 内部根据 `config.renderer` 选 StageRender / LeaferRender |
+| `packages/stage/src/StageRender.ts` | 不变（P0 阶段） | 保留，leafer 稳定后删 |
+| `packages/stage/src/StageMask.ts` | 暂保留 | leafer 路径下用不到，stageOverlay 还要 |
+| `packages/stage/src/StageDragResize.ts` | 暂保留 | P4 删 |
+| `packages/stage/src/ActionManager.ts` | 暂保留 | P4 删 |
+| `packages/editor/src/utils/scroll-viewer.ts` | 暂保留 | P4 删 |
+| `packages/editor/src/components/ScrollViewer.vue` | 暂保留 | P4 删 |
+| `packages/editor/src/editorProps.ts` | 加 prop | `renderer: 'iframe' \| 'leafer'` |
+| `packages/editor/src/services/editor.ts` | 改 | 所有 `runtime?.updatePageId?.()` 等调用删掉或改成 leafer 操作 |
+| `packages/editor/src/layouts/workspace/viewer/Stage.vue` | 改 | watch(page) 改用 setActivePage + leafer 聚焦 |
+| `packages/editor/src/layouts/workspace/viewer/LeaferStage.vue` | 新增 | leafer 专用 Stage 组件 |
+| `packages/editor/src/layouts/preview/PreviewPanel.vue` | 新增 | runtime 预览面板（独立 tab / drawer） |
+| `runtime/vue-runtime-help/src/hooks/use-editor-dsl.ts` | 保留 | runtime 那侧不变，editor 不再调它 |
+| `runtime/react-runtime-help/src/hooks/use-editor-dsl.ts` | 保留 | 同上 |
+| `runtime/vue-runtime-help/src/hooks/use-dsl.ts` | 不变 | runtime 端 |
+| `runtime/react-runtime-help/src/hooks/use-dsl.ts` | 不变 | 同上 |
+| `vue-components/*/src/*.vue` | 不变 | runtime 用，editor 不再直接调 |
+| `react-components/*/src/*.tsx` | 不变 | 同上 |
+| `docs/research/multi-page-infinite-canvas.md` | 加引用 | 注明"leafer 路径下大部分 Step 自动满足" |
+| `playground/src/main.ts` | 加 demo | 演示 `renderer: 'leafer'` 用法 |
+
+**总变更**：~10 个文件新增 / 大改，~5 个文件保留（P4 删），其余业务代码零改动。
+
+---
+
+## 9. 验证标准
+
+完成 M1-M4 后要能验证：
+
+### 功能性
+
+- [ ] 业务方 `renderer: 'leafer'` 切到新画布，4 个内置 type 渲染对齐 Vue 组件（圆角/阴影/渐变/字体都对）
+- [ ] 编辑画布拖入组件 → 落点准确（active page 内）
+- [ ] 点击选中 → 选区高亮 + 右侧属性面板切换
+- [ ] 拖拽改 position → 同步更新到 DSL（store）+ leafer scene
+- [ ] 多 page 切换 → 画布滚到对应 page frame
+- [ ] 多 page 同时渲染 → 切到 fit-to-all 看到所有 page
+- [ ] pan/zoom 流畅（60fps 持续 1 分钟）
+- [ ] 撤销 / 重做：editor 操作正常进历史栈
+- [ ] Runtime 预览面板：打开后跟 Vue 组件实际渲染一致
+
+### 性能
+
+- [ ] 100 个 page + 1000 个组件，pan/zoom 稳定 60fps
+- [ ] 编辑单个 style 改动 < 16ms 重新渲染
+- [ ] 冷启动（leafer 初始化 + 全量绘制）< 500ms（不含 runtime 加载）
+
+### 回归
+
+- [ ] 业务方 `renderer: 'iframe'` 走老逻辑，零回归
+- [ ] 旧 API 兼容：`editorService.select / update / add / remove` 调用方式不变
+- [ ] 旧 props 兼容：`runtimeUrl / render: customizedRender / renderType` 仍能工作（preview 模式）
+
+### 视觉对比
+
+- [ ] 每个内置 type 出一张 leafer 渲染图 + Vue 渲染图，并排对比，肉眼差异 < 5%
+- [ ] 中文字体（PingFang / 思源黑体 / 阿里普惠体）在 leafer 渲染下文字粗细 / 间距跟 Vue 一致
+
+---
+
+## 10. 开放问题（需要业务方拍板）
+
+1. **editor 视觉 vs runtime 视觉的差异容忍度**：业务方能接受多大的"看起来不太一样"？纯靠 shape 函数画，会丢掉一些组件细节（自定义动画、复杂 hover 效果、富文本）
+2. **复杂组件 fallback 策略**：图表 / 表单 / 富文本这类用户自定义组件，是走「HTML overlay」（所见即所得但实现复杂）还是「占位 + 跳转 runtime 预览」（简单但割裂）？建议先占位，预览兜底
+3. **`editor.registerShape` 注册时机**：跟现在 `app.registerComponent` 一样，业务方接入时配两份注册表（一个 runtime 用、一个 editor 用），OK 吗？还是要让用户只写一份（leafer shape 从 Vue 组件自动推导）？后者技术难度大很多，建议先两份
+4. **P0 阶段双 renderer 并行，业务方默认走哪个**：建议默认 `iframe`（保守），业务方显式开 `leafer` 试新；稳定后再换默认
+5. **runtime 预览面板的 UI 形态**：右侧 drawer / 底部抽屉 / 全屏切换 tab？影响业务方使用习惯
+6. **中文字体加载策略**：业务方当前用什么字体（系统 / 阿里普惠 / 自有 webfont）？leafer 走浏览器 canvas 2D 渲染，需要确保字体已加载（用 `document.fonts.ready`）
+7. **leafer 的商业插件 PxGrow**：leafer-ui 开源，PxGrow 是商业插件（高级编辑器套件 / 性能优化）。我们需要用吗？目前看开源能力够，不建议
+8. **删除 `iframe` 路径的时机**：P4 删，但风险高。建议先在内部 / 灰度业务方跑稳 1-2 个 minor 版本再删

--- a/docs/research/multi-page-infinite-canvas.md
+++ b/docs/research/multi-page-infinite-canvas.md
@@ -1,0 +1,468 @@
+# 调研：多页面同时渲染的无限画布
+
+> 目标：底层继续使用 tmagic-editor，把「单页编辑器」改成「多页面同时渲染 + 无限画布」模式。
+> 类比：Figma 的「一个 file 里多个 frame」概念，但粒度提到 MPage（业务页面）这一层；tldraw 的「多 page」借鉴其概念模型，不借鉴其切换式 UI。
+
+> **更新（2026-07-31）**：如果走 leafer-ui 替换 iframe + StageMask 方案，本调研里的 **Step 4（StageMask 适配）/ Step 5（ScrollViewer → CanvasViewer）/ Step 6（page bar 改 setActivePage 的画布部分）大量简化或自动满足**。详细对比见 [leafer-renderer-migration.md §5](./leafer-renderer-migration.md#5-跟多-page-无限画布调研的关系)。建议两条路合并为一份实施计划。
+
+---
+
+## 0. 一句话总结
+
+**关键改造点 = 4 个**：
+
+1. **Runtime 渲染**：从「渲染单 pageConfig」改为「渲染所有 pageConfig，每个 page 包在一个 frame 容器里」，并把当前选中 page 提升为「active / 不可 active 两种状态」。
+2. **画布坐标空间**：从「以当前 page 尺寸为基准」改为「以无限画布为基准 + 每个 page 在画布上有自己的 anchor 坐标」，StageMask / 辅助线 / 选区都要支持跨 page 上下文。
+3. **编辑器 store**：保留 `state.page`（当前编辑页），但新增 `state.canvasLayout`（pageId → `{x, y, width, height}`），让 page bar 不再是「切换渲染」，而是「聚焦 / 滚动到 anchor」。
+4. **交互细节**：拖入组件只对 active page 生效；多选框选只命中 active page；page bar 点击改为「跳转 + 聚焦」而非「销毁 + 重建 Page 实例」。
+
+**核心风险 = 2 个**：
+
+- tmagic 的 `App.page` / `Page` 实例是「单例 + 切换即销毁重建」，要保留这个能力（避免 N 个 page 同时存活导致性能崩），但同时让 runtime 视觉上渲染 N 个 page 的内容 → 需要把「Page 实例生命周期」和「Page 视觉渲染」解耦。
+- 辅助线 / Magic 选区 / 蒙层都依赖 `mask.page` 这个单例 DOM 引用。改成多 page 后要解决「现在选中的 page 是谁」这个事实切换。
+
+---
+
+## 1. 现状盘点（基于代码）
+
+### 1.1 数据模型
+
+| 概念 | 现状 | 文件 |
+| --- | --- | --- |
+| App 根 | `MApp`（`type: 'app'`）含 `items: (MPage \| MPageFragment)[]` | `packages/schema/src/index.ts:198-211` |
+| Page | `MPage extends MContainer`（`type: 'page'`），DSL 里有 items[] | `packages/schema/src/index.ts:184-188` |
+| Page 实例（运行时） | `class Page extends Node`，持有 `nodes: Map<Id, Node>`，按 `MContainer` 子树构建 | `packages/core/src/Page.ts:33-145` |
+| App 实例（运行时） | `class App`，**只持有 `this.page: Page \| undefined`**，是「单当前页」语义 | `packages/core/src/App.ts:35-334`，关键方法 `setPage(id)` `:180-203` |
+| Page 切换 | `App.setPage(id)`：销毁旧 Page 实例 → 新建 → 触发 `page-change` 事件 | `packages/core/src/App.ts:180-203` |
+
+### 1.2 渲染管线
+
+| 层级 | 现状 | 文件 |
+| --- | --- | --- |
+| Editor store | `state.page` 是当前编辑页（store 里也是单例） | `packages/editor/src/services/editor.ts:101-116` |
+| Page bar | 横向 tab 列表，点击 → `editorService.select(id)` 切换 store.page | `packages/editor/src/layouts/page-bar/PageBar.vue:132-134` |
+| Runtime 入口 | 单一 `<MagicUiPage config={pageConfig} />` | `runtime/react/page/App.tsx:31`、`runtime/vue/page/App.vue:2` |
+| useDsl | 监听 `app.page-change` 事件，**返回单 pageConfig** | `runtime/vue-runtime-help/src/hooks/use-dsl.ts:25-34` |
+| useEditorDsl | 编辑器端桥接，`updatePageId(id)` 调 `app.setPage(id)`，单 page 切换 | `runtime/vue-runtime-help/src/hooks/use-editor-dsl.ts:73-89` |
+| StageRender | 单一 iframe / native container 渲染 runtime | `packages/stage/src/StageRender.ts:248-275` |
+| StageMask | `public page: HTMLElement \| null`，蒙层 / 选区 / 辅助线都基于单 page DOM | `packages/stage/src/StageMask.ts:69-188` |
+| ScrollViewer | 以单 page 尺寸为滚动范围 + translate 偏移 | `packages/editor/src/components/ScrollViewer.vue`、`packages/editor/src/utils/scroll-viewer.ts:1-167` |
+| Zoom | 通过 `StageRender.setZoom` 配合 ScrollViewer，作用于单 page | `packages/stage/src/StageRender.ts:101-103` |
+
+### 1.3 关键单例依赖
+
+经过全仓搜索，下面这些点都依赖「只有一个 page DOM」：
+
+1. `App.page` — 运行时 page 实例
+2. `editorService.state.page` — 编辑器 store 当前页
+3. `StageMask.page` — 蒙层关联的 page DOM
+4. `StageMask.pageScrollParent` — page 的滚动父元素
+5. `useDsl().pageConfig` — runtime 端 page 配置
+6. `useEditorDsl().curPageId` — 编辑器 runtime 端当前页 id
+7. `pageChange` 事件语义 — 隐含「渲染目标变了」
+
+---
+
+## 2. 目标态
+
+### 2.1 视觉与交互目标
+
+| 维度 | 目标 |
+| --- | --- |
+| 画布 | 无限 pan/zoom，可以远远缩到全览 N 个 page，也可以 zoom 到 100% 编辑单个 page |
+| Page 布局 | 每个 page 在无限画布上有自己的 anchor 坐标（x, y）和尺寸（width, height），默认 grid 排列 |
+| 同时渲染 | 视口内的所有 page 全部渲染（lazy 加载视口外 page） |
+| 选中态 | 同一时刻只有一个 page 是「active」（可编辑），其他是「idle」（只读 + 半透明 overlay） |
+| 切换 active | 点击某个 idle page → 该 page 高亮，组件树 / 属性面板 / 蒙层 / 辅助线都切到该 page |
+| 拖入 / 编辑 | 拖入组件只对 active page 生效，框选只命中 active page |
+| 页面关系 | 可选：page 之间能画连接线（活动流程图），不在第一版范围 |
+| Page bar | 保留，作为「page 列表 + 缩略图 + 跳转」入口，**不再是「渲染切换」** |
+| Runtime 复用 | 仍然只挂一个 runtime iframe；runtime 内部多 page 协调；性能：冷启动 / 热切换不变慢 |
+
+### 2.2 与现有架构的兼容性
+
+| 现有 | 兼容方案 |
+| --- | --- |
+| `MApp.items: (MPage \| MPageFragment)[]` | **完全保留**，DSL 形态不变 |
+| Page 实例化流程（`Page` 类） | **完全保留**，每个 page 还是一棵 Node 树 |
+| 组件 / 事件 / 数据源 | **完全保留**，每 page 内的逻辑零改动 |
+| `App.page` 单例 | **变成「当前 active page」，加 `App.allPages: Map<Id, Page>` 缓存全部已构建的 Page 实例** |
+| `App.setPage(id)` 语义 | **变成 `App.setActivePage(id)`：只是切 active，Page 实例不重建**（但首次访问 id 仍要走原 Page 构造） |
+| `editorService.state.page` | **保留**，语义变成「active page」 |
+| `useDsl.pageConfig` | **改成 `useDsl()` 返回 `pageConfigs: Ref<Map<Id, MPage>>`**；每个 page 渲染时按 id 取自己的 config |
+| `page-change` 事件 | **改名 + 改语义**：`active-page-change`，并新增 `canvas-layout-change` 事件 |
+| `StageMask.page` | **改成 `StageMask.activePage`**，选区 / 辅助线只绑 active |
+| `ScrollViewer` | **改造成 pan/zoom viewer**，从「以 page 尺寸为基准」改为「以画布尺寸为基准 + matrix transform」 |
+| `runtimeUrl`（iframe） | **保留**，N 个 page 共享一个 runtime 实例；CSS 隔离靠 `.magic-ui-page` 选择器 |
+
+---
+
+## 3. 改造方案（按实施顺序）
+
+### Step 1：数据模型 + store 增量（先动这里，影响面最小）
+
+**目标**：保留所有现有数据，加两样新东西：`canvasLayout` 和 `allPageConfigs`。
+
+涉及文件：
+- `packages/schema/src/index.ts` — 给 `MPage` 加可选的 `canvasLayout?: { x: number; y: number; width: number; height: number; }`（默认从 page 自身 style 推）
+- `packages/editor/src/type.ts` — store state 加 `canvasLayout: Record<Id, CanvasLayout>`、`visiblePageIds?: Id[]`（性能优化用，可选）
+- `packages/editor/src/services/editor.ts` — `set('canvasLayout', ...)` 配套 action；新增 `setCanvasLayout(id, layout)`、`setActivePage(id)` 区分于 `select(id)`
+
+**关键 API 拆分**：
+
+```ts
+// editor service
+select(id):  // 现有：选中节点（包含 page / page-fragment），会触发 set('page', page)
+setActivePage(id):  // 新增：只切 active page，state.page = page，不重渲染 page 树
+getCanvasLayout(id): CanvasLayout | null
+setCanvasLayout(id, layout): void
+```
+
+`select(id)` 对 page 节点的行为从「切 page + 选中 page」拆成「调用 setActivePage + 选中 page」，对组件节点的行为不变（但内部先确保 active page 是该节点所属 page）。
+
+### Step 2：Runtime 渲染从单 page 改为多 page
+
+**目标**：runtime 端同时挂载所有 page，每个 page 是一个 `<MagicUiPage>` 实例，根容器是「无限画布」。
+
+涉及文件：
+- `runtime/vue/page/App.vue`、`runtime/react/page/App.tsx` — 改根组件
+- `runtime/vue-runtime-help/src/hooks/use-dsl.ts`、`runtime/react-runtime-help/src/hooks/use-dsl.ts` — `pageConfig` → `pageConfigs: ComputedRef<Map<Id, MPage>>`，加 `activePageId` ref
+- `runtime/vue-runtime-help/src/components/MagicUiCanvasPage.vue`（新增） — 替代直接 `<MagicUiPage>`，包一层提供 `.magic-ui-page-frame` + `data-page-id` + `data-active="true|false"` + 坐标 `transform: translate(x, y) scale(zoom)`
+
+**关键设计**：
+
+```vue
+<!-- runtime/vue/page/App.vue -->
+<template>
+  <div class="magic-ui-canvas" :style="canvasStyle">
+    <MagicUiCanvasPage
+      v-for="page in pages"
+      :key="page.id"
+      :config="page"
+      :active="page.id === activePageId"
+      :layout="canvasLayout[page.id]"
+    />
+  </div>
+</template>
+```
+
+```css
+.magic-ui-canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;        /* 画布外层不滚动，由 ScrollViewer/pan 控 */
+  background: #f5f5f5;     /* 区别于 page 内白底 */
+}
+.magic-ui-page-frame {
+  position: absolute;
+  /* transform 由 props 动态给 */
+}
+.magic-ui-page-frame[data-active="false"] {
+  pointer-events: none;    /* idle page 不可点 */
+  filter: brightness(0.95);
+}
+```
+
+**active 切换的视觉效果**：active page 有边框 / 阴影；idle page 半透明 + 不可交互。
+
+### Step 3：Page 实例生命周期与渲染解耦
+
+**目标**：N 个 page 都能被 runtime 渲染，但 Page 实例只在被「首次访问」时构造。
+
+涉及文件：
+- `packages/core/src/App.ts` — `this.page` 保留为「active page」；新增 `this.allPages: Map<Id, Page> = new Map()`、`getOrCreatePage(id)` 方法
+- `packages/core/src/Page.ts` — 单 page 行为不变
+
+**关键改动**：
+
+```ts
+// App.ts
+public allPages: Map<Id, Page> = new Map();
+
+public getOrCreatePage(id: Id): Page | undefined {
+  if (this.allPages.has(id)) return this.allPages.get(id);
+  const cfg = this.dsl?.items.find(p => `${p.id}` === `${id}`);
+  if (!cfg) return undefined;
+  const page = new Page({ config: cfg, app: this });
+  this.allPages.set(id, page);
+  return page;
+}
+
+public setActivePage(id: Id) {
+  const page = this.getOrCreatePage(id);
+  if (!page) return;
+  this.page = page;  // 保留兼容
+  super.emit('active-page-change', page);
+}
+
+// 删掉 setPage 里的「destroy 旧 page」逻辑
+public setPage(id: Id) {
+  // 兼容旧调用，语义改成「setActivePage」
+  this.setActivePage(id);
+}
+
+// destroy() 改为遍历 allPages
+public destroy() {
+  this.allPages.forEach(p => p.destroy());
+  this.allPages.clear();
+  // ...
+}
+```
+
+**性能考量**：
+- 用户有 100 个 page 时，全部构造会爆内存 → 加 `maxLivePages`（默认 5-10），LRU 淘汰冷 page
+- 淘汰的 page 仍在 `dsl.items` 里，runtime 还能渲染（runtime 拿 `pageConfigs` 从 dsl 取，不需要 page 实例），但 `App.getNode(id)` 在被淘汰 page 里会返回 undefined，需要上层按需重建
+
+### Step 4：StageMask / 选区 / 辅助线适配
+
+**目标**：选区 / 辅助线 / 蒙层只对 active page 生效，坐标系以画布为基准。
+
+涉及文件：
+- `packages/stage/src/StageMask.ts` — `page` → `activePage`，`setLayout(el)` 不变（el 永远在 active page 内）
+- `packages/stage/src/StageRender.ts` — `getTargetElement(id)` 要扫所有 page DOM（按 `data-page-id` 过滤，或全局 getElById 后校验）
+- `packages/stage/src/types.ts` — Runtime 接口 `updatePageId` 保留兼容（语义改成 `setActivePageId`），新增 `setCanvasLayout(id, layout)`
+
+**关键改动**：
+
+```ts
+// StageMask.ts
+public activePage: HTMLElement | null = null;  // 替代 page
+public pageFrames: Map<Id, HTMLElement> = new Map();  // 全部 page DOM
+
+public observePageFrame(pageId: Id, el: HTMLElement) {
+  this.pageFrames.set(pageId, el);
+  if (pageId === this.currentActiveId) {
+    this.activePage = el;
+  }
+}
+```
+
+**辅助线要决定**：辅助线只对齐 active page 内的元素，还是全画布所有 page 元素？
+- 推荐：只对齐 active page（活动页面内 snap 体验不变，跨 page snap 容易误触）
+- 实施：`computeGuides` 从 `app.page.nodes` 改成 `app.activePage.nodes`，约束范围
+
+### Step 5：ScrollViewer 改造成 pan/zoom viewer
+
+**目标**：从「以 page 尺寸滚动」改为「以画布为无限空间 + 仿 Figma 的 pan/zoom」。
+
+涉及文件：
+- `packages/editor/src/components/ScrollViewer.vue` — 改名为 `CanvasViewer.vue`（或保留旧名，加 prop `mode: 'page' | 'canvas'`）
+- `packages/editor/src/utils/scroll-viewer.ts` — `CanvasViewer` 类（新增），继承 EventEmitter，pan 改 transform 而不是 scroll
+
+**关键设计**：
+
+```ts
+class CanvasViewer {
+  private scale = 1;       // 整体缩放
+  private panX = 0;        // 画布平移 X
+  private panY = 0;        // 画布平移 Y
+
+  setViewport(pan: Point, scale: number) {
+    this.panX = pan.x;
+    this.panY = pan.y;
+    this.scale = scale;
+    this.target.style.transform = `translate(${panX}px, ${panY}px) scale(${scale})`;
+  }
+
+  fitToActivePage(pageLayout: CanvasLayout, containerSize: Size) {
+    // 类似 Figma 的「按 Z 聚焦到当前 page」
+    this.setViewport(
+      {
+        x: containerSize.width / 2 - (pageLayout.x + pageLayout.width / 2) * this.scale,
+        y: containerSize.height / 2 - (pageLayout.y + pageLayout.height / 2) * this.scale,
+      },
+      this.scale,
+    );
+  }
+
+  fitToAllPages(pages: CanvasLayout[], containerSize: Size) {
+    // 类似 Figma 的「Shift + 1」缩放到全览
+    const bounds = computeBounds(pages);
+    // ... 自适应计算 pan + scale
+  }
+}
+```
+
+**平移 / 缩放交互**：
+- 滚轮 = 缩放（以光标位置为锚点，仿 Figma）
+- Space + 拖拽 / 中键拖拽 = 平移
+- Trackpad 双指拖 = 平移，捏合 = 缩放
+- 复用现有 `StageMask` 的 wheelHandler 思路，但要区分「缩放」vs「滚动」
+
+### Step 6：编辑器侧 page 切换交互
+
+**目标**：page bar 点击不再是「销毁 + 重建」，是「平移 + 聚焦 + 高亮 active」。
+
+涉及文件：
+- `packages/editor/src/layouts/page-bar/PageBar.vue` — `switchPage(id)` 改为 `setActivePage(id)` + 调 `CanvasViewer.focusToPage(id)`
+- `packages/editor/src/layouts/workspace/viewer/Stage.vue` — `watch(page, ...)` 改为 `setActivePage` + 平移动画
+
+```ts
+// PageBar.vue
+const switchPage = (id: Id) => {
+  // 不再调 editorService.select(id)（那会触发 select 事件 + 历史栈）
+  // 改为：
+  editorService.setActivePage(id);
+  canvasViewer.focusToPage(id);
+};
+```
+
+**要不要保留 select(pageId) 兼容**？建议保留，但内部转发到 setActivePage + addToSelection。
+
+### Step 7：拖入 / 框选只对 active page 生效
+
+**目标**：现有拖入逻辑已经基于 `state.page`，state.page 改成 active page 后自然只对 active 生效。要修的是「跨 page 框选」——
+
+涉及文件：
+- `packages/stage/src/ActionManager.ts` — `multiSelect` 选区范围限定在 active page DOM 内
+- `packages/editor/src/layouts/workspace/viewer/Stage.vue` — `dropHandler` 已基于 `page.value`，自动正确
+
+**额外考虑**：拖入组件时如果光标在 idle page 区域，是否自动切到该 page？
+- 推荐：**是**，光标在哪个 page 上，drop 时就 setActivePage 到那个 page，再 add。减少误操作。
+
+### Step 8（可选）：缩略图 / page bar 增强
+
+- page tab 右侧加小缩略图（按画布当前 zoom 渲染一份小图，或者用 `@zumer/snapdom` 抓 page DOM 成图）
+- page bar 改为左侧 dock（Figma 风格），tab 缩略图纵向排列
+
+### Step 9（可选）：page 间连接线
+
+- 新增 `MNode.type = 'flow-link'`，source / target 指向不同 pageId
+- 画布层渲染 SVG overlay，按 anchor 坐标连线
+- **不建议放进第一版**，独立 feature
+
+---
+
+## 4. 关键技术风险与对策
+
+### 风险 1：N 个 page 全实例化内存爆炸
+
+**对策**：
+- LRU 缓存，maxLivePages 默认 5-10
+- 超限时淘汰最冷 page（保留 dsl 引用，销毁 Node 实例 + DOM）
+- 重新访问被淘汰 page 时按需重建（`getOrCreatePage` 已就位）
+- runtime 端有 `pageConfigs: Map<Id, MPage>`（直接从 dsl.items 取，**不依赖 Page 实例**），所以即使 Page 实例被淘汰，runtime 仍然能渲染
+
+### 风险 2：辅助线 / 选区坐标错位
+
+**对策**：
+- 所有事件坐标都先过 `getCanvasMatrix()` 反变换到画布坐标
+- 选区 / 辅助线生成时限定 `app.activePage.nodes`（不要全画布）
+- 拖入组件时按 `canvasLayout[activePageId]` 算初始 top/left
+
+### 风险 3：page 之间 z-index / 遮挡
+
+**对策**：
+- 默认 z-index 按 page 在 dsl.items 里的顺序：后面的盖前面的
+- active page 永远 z-index 最高
+- 切换 active 时 z-index 动画过渡（CSS transition）
+
+### 风险 4：runtime 端 useDsl 单 pageConfig 假设被打破
+
+**对策**：
+- `useDsl` 升级为 `useCanvasDsl`，返回 `{ pageConfigs, activePageId, canvasLayout }`
+- 旧 `useDsl` 保留为 `useCanvasDsl().pageConfigs.get(activePageId)` 的 thin wrapper，**不立即删除**，给业务方迁移时间
+- 在 `@deprecated` 里标 `useDsl`，1-2 个 minor 版本后删
+
+### 风险 5：第三方业务组件假设「只有一个 page 根节点」
+
+**对策**：
+- 业务组件的 `useDsl` 仍然能拿到单 pageConfig（见风险 4 wrapper）
+- 业务组件的 `useEditorDsl().root.value` 仍然能拿到 MApp 根
+- 业务组件自己只需要改「监听哪个 page」——默认监听 active page，需要监听全部的用新 hook
+
+---
+
+## 5. 业界参考
+
+| 产品 | 多 page 模型 | 无限画布 | 我们的借鉴点 |
+| --- | --- | --- | --- |
+| **Figma** | 1 file = 多 page，每 page 内多 frame | ✅ 无限 + pan/zoom | 「多 frame 模式」概念上同构；fit-to-page / fit-to-all 交互 |
+| **tldraw** | 多 page，**单 page 同时渲染** | ✅ 无限 | page 概念 + 切换交互；page 内坐标空间定义 |
+| **excalidraw** | 单 page（无 page 概念） | ✅ 无限 | library 拖入的多元素管理 |
+| **FigJam** | 多 page 切 | ✅ 无限 | sticky note 自由摆放概念 |
+| **Miro / Mural** | 多 board 切 | ✅ 无限 | board 内 frame 概念 |
+
+**最直接的参考 = Figma**，但 Figma 的「frame」≠ tmagic 的「MPage」：
+- Figma frame = 视觉容器，可嵌套，可画连接线
+- tmagic MPage = 业务页面，DSL 顶层节点，**不能嵌套**（但 pageFragment 可被引用）
+
+我们要做的是「把 Figma 那种『多个 frame 放在一个 file』的 UX 借过来，套到 tmagic 的『多 MPage』场景」。
+
+---
+
+## 6. 实施路线建议
+
+| 阶段 | 内容 | 风险 | 估时（仅供参考） |
+| --- | --- | --- | --- |
+| **P0 — 基础** | Step 1（store 增量）+ Step 6（page bar 改 setActivePage） | 低，向后兼容 | 1 周 |
+| **P0 — 渲染** | Step 2（runtime 多 page 渲染）+ Step 3（Page 实例缓存） | 中，runtime 改根组件 | 2 周 |
+| **P1 — 交互** | Step 4（StageMask 适配）+ Step 7（drop 切 active） | 中 | 1-2 周 |
+| **P1 — 画布** | Step 5（ScrollViewer → CanvasViewer） | 高，交互手感要打磨 | 2 周 |
+| **P2 — 增强** | Step 8（缩略图）/ Step 9（连接线，可选） | 低 | 1-2 周 |
+
+**总估时 ~6-8 周**，按 1 个前端全职算。
+
+**里程碑**：
+- M1（P0 完成）：可以同时看到 N 个 page，点击切换 active，但画布仍然受限于原 ScrollViewer 行为（没真正的 pan/zoom）
+- M2（P1 完成）：画布变成真正的无限 pan/zoom，可以缩放到全览，可以聚焦到单 page
+- M3（P2 完成）：page bar 缩略图、flow link（可选）
+
+---
+
+## 7. 关键文件改动清单（汇总）
+
+| 文件 | 改动类型 | 说明 |
+| --- | --- | --- |
+| `packages/schema/src/index.ts` | 加字段 | `MPage.canvasLayout?: { x, y, width, height }` |
+| `packages/core/src/App.ts` | 改 | `page` → `activePage`，加 `allPages` + `getOrCreatePage` + `setActivePage` |
+| `packages/core/src/Page.ts` | 不变 | 单 page 行为零改动 |
+| `packages/editor/src/services/editor.ts` | 加 action | `setActivePage`、`setCanvasLayout`，调整 `select` 对 page 的行为 |
+| `packages/editor/src/type.ts` | 加字段 | store state 加 `canvasLayout` |
+| `packages/editor/src/layouts/workspace/viewer/Stage.vue` | 改 | `watch(page)` 改用 setActivePage + CanvasViewer |
+| `packages/editor/src/layouts/page-bar/PageBar.vue` | 改 | `switchPage` 改 setActivePage + 调 CanvasViewer.focusToPage |
+| `packages/editor/src/components/ScrollViewer.vue` | 改/重命名 | 加 `mode: 'page' \| 'canvas'`，canvas 模式即新 CanvasViewer |
+| `packages/editor/src/utils/scroll-viewer.ts` | 加类 | `CanvasViewer` 类（pan + zoom + fit） |
+| `packages/stage/src/StageMask.ts` | 改 | `page` → `activePage`，加 `pageFrames` map |
+| `packages/stage/src/StageRender.ts` | 改 | `getTargetElement` 扫所有 page DOM |
+| `packages/stage/src/types.ts` | 加接口 | `Runtime.setActivePageId` / `Runtime.setCanvasLayout` |
+| `runtime/vue/page/App.vue` | 重写根 | 改 `<MagicUiCanvasPage v-for>` |
+| `runtime/react/page/App.tsx` | 重写根 | 同上 |
+| `runtime/vue-runtime-help/src/hooks/use-dsl.ts` | 加 / 改 | 新增 `useCanvasDsl`，旧 `useDsl` 保留为 wrapper |
+| `runtime/react-runtime-help/src/hooks/use-dsl.ts` | 同上 | 同上 |
+| `runtime/vue-runtime-help/src/components/MagicUiCanvasPage.vue` | 新增 | 单 page frame 容器组件 |
+| `runtime/react-runtime-help/src/components/MagicUiCanvasPage.tsx` | 新增 | 同上 |
+
+**未列出的影响点**（需要 grep 全面评估后再做）：
+- 所有使用 `editorService.get('page')` 的地方，行为不变（仍是 active page），但需要确认没有「假设 page 切换会重置 DOM」的逻辑
+- 所有 `useDsl().pageConfig` 的业务方，建议加 deprecation 提示，但**不强制**改（wrapper 能撑住）
+- 第三方 iframe runtime（`stageOverlay` / `stage.ts` 里的 `customizedRender`）—— 评估是否要支持多 page 模式
+
+---
+
+## 8. 验证标准
+
+完成 P0 + P1 后要能验证：
+
+- [ ] 同时挂 3+ page 在画布上，pan/zoom 流畅（60fps）
+- [ ] 切换 active page < 100ms（无白屏）
+- [ ] 拖入组件：drop 在 active page 区域内 → 加到 active；drop 在 idle page 区域 → 自动切 active 再加
+- [ ] 框选：只在 active page 范围内生效
+- [ ] 缩放到全览（fit-to-all）：能看到所有 page 的 frame
+- [ ] 缩放到聚焦（fit-to-active）：当前 active page 居中显示
+- [ ] page bar 点击 = 切 active + 平移到该 page，不销毁 Page 实例
+- [ ] 历史栈（撤销 / 重做）：page 切换不进历史栈，page 内部编辑进历史栈
+- [ ] 跨 page 引用（pageFragment）：仍按现有机制工作，不受影响
+- [ ] 单 page 模式（业务方不启用 infinite canvas）向后兼容：旧用法零改动
+
+---
+
+## 9. 开放问题（需要业务方拍板）
+
+1. **page 之间要不要画连接线**（活动流程图）？第一版砍掉 / 第一版做？
+2. **缩略图**：page bar 缩略图是实时抓 DOM 还是提前缓存？实时抓需要用 `@zumer/snapdom`，可能阻塞 UI 线程，建议后台 worker 缓存。
+3. **多 page 命名空间**：DSL 里的 `MPage.id` 现在是业务自己定的，多 page 同时渲染时 `getElById` 会不会跨 page 撞 id？需要扫一遍业务方数据。
+4. **active page 的视觉提示**：边框 / 阴影 / 顶栏高亮，选哪种？Figma 是顶栏高亮 + 边框 + 阴影叠用。
+5. **历史栈粒度**：page 切换是否要进历史栈？目前是不进，保持不变。
+6. **业务组件升级**：第三方业务组件假设「只有一个 page 」，要不要提供一个 `useActivePageId()` hook 帮他们无痛迁移？

--- a/leafer-components/__tests__/utils.spec.ts
+++ b/leafer-components/__tests__/utils.spec.ts
@@ -1,0 +1,168 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeColor,
+  parseFontWeight,
+  parseGradient,
+  parsePx,
+  parseShadow,
+} from '../src/utils'
+
+describe('parsePx', () => {
+  it('returns undefined for null / undefined / empty', () => {
+    expect(parsePx(null)).toBeUndefined()
+    expect(parsePx(undefined)).toBeUndefined()
+    expect(parsePx('')).toBeUndefined()
+  })
+
+  it('parses number as-is', () => {
+    expect(parsePx(100)).toBe(100)
+    expect(parsePx(0)).toBe(0)
+    expect(parsePx(-12.5)).toBe(-12.5)
+  })
+
+  it('parses "100" / "100px" to 100', () => {
+    expect(parsePx('100')).toBe(100)
+    expect(parsePx('100px')).toBe(100)
+    expect(parsePx('-50px')).toBe(-50)
+    expect(parsePx('12.5px')).toBe(12.5)
+  })
+
+  it('converts pt to px (×1.333)', () => {
+    expect(parsePx('10pt')).toBeCloseTo(13.33, 1)
+  })
+
+  it('returns undefined for % / auto', () => {
+    expect(parsePx('50%')).toBeUndefined()
+    expect(parsePx('auto')).toBeUndefined()
+  })
+
+  it('handles non-finite gracefully', () => {
+    expect(parsePx(NaN)).toBeUndefined()
+    expect(parsePx(Infinity)).toBeUndefined()
+  })
+})
+
+describe('parseShadow', () => {
+  it('returns undefined for empty / none', () => {
+    expect(parseShadow(undefined)).toBeUndefined()
+    expect(parseShadow(null)).toBeUndefined()
+    expect(parseShadow('')).toBeUndefined()
+    expect(parseShadow('none')).toBeUndefined()
+  })
+
+  it('parses basic box-shadow', () => {
+    const result = parseShadow('0 2px 8px rgba(0, 0, 0, 0.15)')
+    expect(result).toEqual({
+      x: 0,
+      y: 2,
+      blur: 8,
+      spread: 0,
+      color: 'rgba(0, 0, 0, 0.15)',
+      inset: false,
+    })
+  })
+
+  it('parses inset shadow', () => {
+    const result = parseShadow('inset 0 1px 0 #fff')
+    expect(result?.inset).toBe(true)
+    expect(result?.color).toBe('#fff')
+  })
+
+  it('takes first shadow from multiple', () => {
+    const result = parseShadow('0 1px 2px red, 0 2px 4px blue')
+    expect(result?.color).toBe('red')
+  })
+})
+
+describe('parseGradient', () => {
+  it('returns undefined for non-gradient', () => {
+    expect(parseGradient(undefined)).toBeUndefined()
+    expect(parseGradient('red')).toBeUndefined()
+  })
+
+  it('parses linear-gradient with default angle', () => {
+    const result = parseGradient('linear-gradient(red, blue)')
+    expect(result?.type).toBe('linear')
+    if (result?.type === 'linear') {
+      expect(result.stops).toHaveLength(2)
+      expect(result.stops[0].color).toBe('red')
+    }
+  })
+
+  it('parses linear-gradient with "to right"', () => {
+    const result = parseGradient('linear-gradient(to right, red, blue)')
+    expect(result?.type).toBe('linear')
+    if (result?.type === 'linear') {
+      expect(result.angle).toBe(90)
+    }
+  })
+
+  it('parses linear-gradient with deg', () => {
+    const result = parseGradient('linear-gradient(45deg, red, blue)')
+    expect(result?.type).toBe('linear')
+    if (result?.type === 'linear') {
+      expect(result.angle).toBe(45)
+    }
+  })
+
+  it('parses radial-gradient', () => {
+    const result = parseGradient('radial-gradient(circle, red, blue)')
+    expect(result?.type).toBe('radial')
+  })
+
+  it('parses conic-gradient', () => {
+    const result = parseGradient('conic-gradient(red, blue, green)')
+    expect(result?.type).toBe('conic')
+  })
+})
+
+describe('parseFontWeight', () => {
+  it('returns undefined for empty', () => {
+    expect(parseFontWeight(undefined)).toBeUndefined()
+    expect(parseFontWeight(null)).toBeUndefined()
+  })
+
+  it('handles named values', () => {
+    expect(parseFontWeight('normal')).toBe(400)
+    expect(parseFontWeight('bold')).toBe(700)
+    expect(parseFontWeight('lighter')).toBe('lighter')
+  })
+
+  it('handles number / numeric string', () => {
+    expect(parseFontWeight(700)).toBe(700)
+    expect(parseFontWeight('500')).toBe(500)
+  })
+})
+
+describe('normalizeColor', () => {
+  it('returns trimmed string', () => {
+    expect(normalizeColor('  #fff  ')).toBe('#fff')
+    expect(normalizeColor('rgba(0,0,0,.5)')).toBe('rgba(0,0,0,.5)')
+  })
+
+  it('returns undefined for empty / non-string', () => {
+    expect(normalizeColor(undefined)).toBeUndefined()
+    expect(normalizeColor(null)).toBeUndefined()
+    expect(normalizeColor(123)).toBeUndefined()
+    expect(normalizeColor('')).toBeUndefined()
+  })
+})

--- a/leafer-components/package.json
+++ b/leafer-components/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@leafer-components",
+  "version": "0.0.1",
+  "description": "TMagic editor 端 leafer-ui shape 渲染器集合。仅用于 editor 画布渲染,不用作 runtime 替代品。",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./utils": "./src/utils.ts",
+    "./button": "./src/button.ts",
+    "./text": "./src/text.ts",
+    "./img": "./src/img.ts",
+    "./container": "./src/container.ts",
+    "./overlay": "./src/overlay.ts",
+    "./page": "./src/page.ts",
+    "./qrcode": "./src/qrcode.ts",
+    "./page-fragment": "./src/page-fragment.ts",
+    "./page-fragment-container": "./src/page-fragment-container.ts",
+    "./iterator-container": "./src/iterator-container.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tencent/tmagic-editor.git"
+  },
+  "peerDependencies": {
+    "leafer-ui": "^2.0.0",
+    "@tmagic/schema": "workspace:^"
+  },
+  "devDependencies": {
+    "leafer-ui": "^2.0.0",
+    "@tmagic/schema": "workspace:^",
+    "vitest": "^4.1.10"
+  }
+}

--- a/leafer-components/src/button.ts
+++ b/leafer-components/src/button.ts
@@ -1,0 +1,70 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Group, Rect, Text } from 'leafer-ui'
+
+import type { MComponent } from '@tmagic/schema'
+
+import {
+  normalizeColor,
+  parseFontWeight,
+  parsePx,
+  type ShapeFn,
+} from './utils'
+
+/**
+ * 按钮 = Group[Rect(底色) + Text(文字)]
+ * 与 vue-components/button 和 react-components/button 的 <button> 渲染对齐
+ */
+const shape: ShapeFn = (config) => {
+  const c = config as MComponent & { text?: string }
+  const w = parsePx(c.style?.width)
+  const h = parsePx(c.style?.height)
+
+  const group = new Group({
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: w,
+    height: h,
+  })
+
+  group.add(
+    new Rect({
+      width: w,
+      height: h,
+      fill: normalizeColor(c.style?.backgroundColor) ?? '#409EFF',
+      cornerRadius: parsePx(c.style?.borderRadius) ?? 4,
+    }),
+  )
+
+  group.add(
+    new Text({
+      text: c.text ?? '',
+      fill: normalizeColor(c.style?.color) ?? '#fff',
+      fontSize: parsePx(c.style?.fontSize) ?? 14,
+      fontWeight: parseFontWeight(c.style?.fontWeight),
+      fontFamily: c.style?.fontFamily,
+      textAlign: 'center',
+      verticalAlign: 'middle',
+    }),
+  )
+
+  return group
+}
+
+export default shape

--- a/leafer-components/src/container.ts
+++ b/leafer-components/src/container.ts
@@ -1,0 +1,47 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Frame } from 'leafer-ui'
+
+import type { MContainer } from '@tmagic/schema'
+
+import {
+  normalizeColor,
+  parsePx,
+  type ShapeFn,
+  type ShapeWithChildren,
+} from './utils'
+
+/**
+ * 容器 = Frame,递归渲染 config.items
+ * 业务方在 ShapeRegistry 里通过 ctx.renderChildren 处理 children
+ */
+const shape: ShapeFn = (config, _ctx): ShapeWithChildren => {
+  const c = config as MContainer
+  const node = new Frame({
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: parsePx(c.style?.width),
+    height: parsePx(c.style?.height),
+    fill: normalizeColor(c.style?.backgroundColor),
+    cornerRadius: parsePx(c.style?.borderRadius),
+  })
+  return { node, children: c.items ?? [] }
+}
+
+export default shape

--- a/leafer-components/src/img.ts
+++ b/leafer-components/src/img.ts
@@ -16,20 +16,21 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import { Image } from 'leafer-ui'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+import type { MComponent } from '@tmagic/schema'
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
+import { parsePx, type ShapeFn } from './utils'
 
-export default StageCore;
+const shape: ShapeFn = (config) => {
+  const c = config as MComponent & { url?: string }
+  return new Image({
+    url: c.url ?? '',
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: parsePx(c.style?.width),
+    height: parsePx(c.style?.height),
+  })
+}
+
+export default shape

--- a/leafer-components/src/index.ts
+++ b/leafer-components/src/index.ts
@@ -1,0 +1,80 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * 统一入口:editor 端可一次性 import 所有 shape。
+ * 业务方也可单独 import `import buttonShape from '@leafer-components/button'`。
+ *
+ * 与 vue-components / react-components 对应关系:
+ *   vue-components/button     ↔ leafer-components/button
+ *   react-components/button    ↔ leafer-components/button
+ *
+ * leafer-components 仅为 editor 画布渲染使用,不要在 runtime 端使用。
+ */
+
+import button from './button'
+import text from './text'
+import img from './img'
+import container from './container'
+import overlay from './overlay'
+import page from './page'
+import qrcode from './qrcode'
+import pageFragment from './page-fragment'
+import pageFragmentContainer from './page-fragment-container'
+import iteratorContainer from './iterator-container'
+
+export { default as button } from './button'
+export { default as text } from './text'
+export { default as img } from './img'
+export { default as container } from './container'
+export { default as overlay } from './overlay'
+export { default as page } from './page'
+export { default as qrcode } from './qrcode'
+export { default as pageFragment } from './page-fragment'
+export { default as pageFragmentContainer } from './page-fragment-container'
+export { default as iteratorContainer } from './iterator-container'
+
+export {
+  parsePx,
+  parseShadow,
+  parseGradient,
+  parseFontWeight,
+  normalizeColor,
+  type ShapeFn,
+  type ShapeContext,
+  type ShapeWithChildren,
+  type LeaferShadow,
+  type LeaferFill,
+  type LeaferColorStop,
+} from './utils'
+
+export { buildPlaceholderRect } from './placeholder'
+
+// 业务方 `import * as lc from '@leafer-components'` 时拿到所有
+export default {
+  button,
+  text,
+  img,
+  container,
+  overlay,
+  page,
+  qrcode,
+  pageFragment,
+  pageFragmentContainer,
+  iteratorContainer,
+}

--- a/leafer-components/src/iterator-container.ts
+++ b/leafer-components/src/iterator-container.ts
@@ -16,20 +16,13 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import type { ShapeFn } from './utils'
+import { buildPlaceholderRect } from './placeholder'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+/**
+ * iterator-container placeholder:数据源驱动的循环容器。
+ * editor 端占位,运行时通过 dataSource 展开。
+ */
+const shape: ShapeFn = (config) => buildPlaceholderRect(config)
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
-
-export default StageCore;
+export default shape

--- a/leafer-components/src/overlay.ts
+++ b/leafer-components/src/overlay.ts
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Frame } from 'leafer-ui'
+
+import type { MContainer } from '@tmagic/schema'
+
+import {
+  normalizeColor,
+  parsePx,
+  type ShapeFn,
+  type ShapeWithChildren,
+} from './utils'
+
+/**
+ * overlay = 同 container,业务方可后续区分(置顶 / 模态 / fixed 定位等)
+ */
+const shape: ShapeFn = (config, _ctx): ShapeWithChildren => {
+  const c = config as MContainer
+  const node = new Frame({
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: parsePx(c.style?.width),
+    height: parsePx(c.style?.height),
+    fill: normalizeColor(c.style?.backgroundColor),
+    cornerRadius: parsePx(c.style?.borderRadius),
+  })
+  return { node, children: c.items ?? [] }
+}
+
+export default shape

--- a/leafer-components/src/page-fragment-container.ts
+++ b/leafer-components/src/page-fragment-container.ts
@@ -16,20 +16,13 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import type { ShapeFn } from './utils'
+import { buildPlaceholderRect } from './placeholder'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+/**
+ * page-fragment-container placeholder:容器指向 page-fragment。
+ * editor 端占位,业务方可后续实现解析逻辑。
+ */
+const shape: ShapeFn = (config) => buildPlaceholderRect(config)
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
-
-export default StageCore;
+export default shape

--- a/leafer-components/src/page-fragment.ts
+++ b/leafer-components/src/page-fragment.ts
@@ -16,20 +16,13 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import type { ShapeFn } from './utils'
+import { buildPlaceholderRect } from './placeholder'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+/**
+ * page-fragment placeholder:跨页引用的页面片,editor 端暂时占位,
+ * 真实内容在 runtime 端通过引用加载。
+ */
+const shape: ShapeFn = (config) => buildPlaceholderRect(config)
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
-
-export default StageCore;
+export default shape

--- a/leafer-components/src/page.ts
+++ b/leafer-components/src/page.ts
@@ -16,20 +16,26 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import { Frame } from 'leafer-ui'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+import type { MPage } from '@tmagic/schema'
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
+import { parsePx, type ShapeFn, type ShapeWithChildren } from './utils'
 
-export default StageCore;
+/**
+ * page = 根 Frame,持有 items。
+ * 与 vue-components/page 行为对齐(page 渲染为容器组件,内含 items)。
+ */
+const shape: ShapeFn = (config, _ctx): ShapeWithChildren => {
+  const c = config as MPage
+  const node = new Frame({
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: parsePx(c.style?.width),
+    height: parsePx(c.style?.height),
+    fill: c.style?.backgroundColor as string | undefined,
+  })
+  return { node, children: c.items ?? [] }
+}
+
+export default shape

--- a/leafer-components/src/placeholder.ts
+++ b/leafer-components/src/placeholder.ts
@@ -16,20 +16,25 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import { Rect } from 'leafer-ui'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+import type { MComponent } from '@tmagic/core'
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
+import { parsePx } from './utils'
 
-export default StageCore;
+/**
+ * 通用占位矩形:浅灰背景 + 边框,供未实现 shape 的 type 使用。
+ * qrcode / page-fragment / page-fragment-container / iterator-container 都用这个。
+ */
+export const buildPlaceholderRect = (config: MComponent): Rect => {
+  const w = parsePx(config.style?.width) ?? 100
+  const h = parsePx(config.style?.height) ?? 100
+  return new Rect({
+    width: w,
+    height: h,
+    fill: '#f5f5f5',
+    stroke: { type: 'solid', color: '#ddd' } as any,
+    strokeWidth: 1,
+    cornerRadius: 4,
+  })
+}

--- a/leafer-components/src/qrcode.ts
+++ b/leafer-components/src/qrcode.ts
@@ -16,20 +16,13 @@
  * limitations under the License.
  */
 
-import StageCore from './StageCore';
+import type { ShapeFn } from './utils'
+import { buildPlaceholderRect } from './placeholder'
 
-export * from 'moveable';
-export type { GuidesOptions } from '@scena/guides';
+/**
+ * qrcode placeholder:runtime 端用 qrcode 库生成 canvas 绘制,
+ * editor 端暂时画浅灰矩形占位,业务方需要可在 @leafer-components/qrcode 里覆写。
+ */
+const shape: ShapeFn = (config) => buildPlaceholderRect(config)
 
-export { default as StageRender } from './StageRender';
-export { default as StageMask } from './StageMask';
-export { default as StageDragResize } from './StageDragResize';
-export { default as LeaferShapeRegistry } from './LeaferShapeRegistry';
-export type { ShapeFn, ShapeContext, ShapeWithChildren } from './LeaferShapeRegistry';
-export * from './types';
-export * from './const';
-export * from './util';
-export * from './MoveableActionsAble';
-export { default as MoveableActionsAble } from './MoveableActionsAble';
-
-export default StageCore;
+export default shape

--- a/leafer-components/src/text.ts
+++ b/leafer-components/src/text.ts
@@ -1,0 +1,49 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Text } from 'leafer-ui'
+
+import type { MComponent } from '@tmagic/schema'
+
+import {
+  normalizeColor,
+  parseFontWeight,
+  parsePx,
+  type ShapeFn,
+} from './utils'
+
+const shape: ShapeFn = (config) => {
+  const c = config as MComponent & { text?: string }
+  return new Text({
+    text: c.text ?? '',
+    x: parsePx(c.style?.left) ?? 0,
+    y: parsePx(c.style?.top) ?? 0,
+    width: parsePx(c.style?.width),
+    height: parsePx(c.style?.height),
+    fill: normalizeColor(c.style?.color),
+    fontSize: parsePx(c.style?.fontSize) ?? 14,
+    fontWeight: parseFontWeight(c.style?.fontWeight),
+    fontFamily: c.style?.fontFamily,
+    textAlign: c.style?.textAlign ?? 'left',
+    fontStyle: c.style?.fontStyle,
+    lineHeight: parsePx(c.style?.lineHeight),
+    letterSpacing: parsePx(c.style?.letterSpacing),
+  })
+}
+
+export default shape

--- a/leafer-components/src/utils.ts
+++ b/leafer-components/src/utils.ts
@@ -1,0 +1,267 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IUI } from 'leafer-ui'
+
+import type { MComponent, MContainer, MNode } from '@tmagic/schema'
+
+/**
+ * 单一 leafer shape 节点的描述。
+ * - return 一个 leafer UI:画单个独立节点
+ * - return { node, children }:node 是 leafer 容器,children 是子 MNode 列表(由 ShapeRegistry 递归处理)
+ * - return null:不画(占位)
+ */
+export type ShapeFn = (config: MComponent, ctx: ShapeContext) => IUI | ShapeWithChildren | null
+
+export interface ShapeWithChildren {
+  node: IUI
+  children?: MNode[]
+}
+
+export interface ShapeContext {
+  /** 通过 type 递归查子节点 shape */
+  resolve(type: string): ShapeFn | undefined
+  /** 由 ShapeRegistry 注入,递归调用子 shape */
+  renderChildren(children: MNode[]): IUI[]
+}
+
+// ---------------------------------------------------------------------------
+// 数值 / 单位 / 长度
+// ---------------------------------------------------------------------------
+
+/**
+ * 把 CSS 风格的长度值解析成像素数字。
+ * - 数字直接返回
+ * - '100' / '100px' → 100
+ * - '50%' / 'auto' / null / undefined → undefined(由调用方决定 fallback)
+ */
+export const parsePx = (v: unknown): number | undefined => {
+  if (v == null || v === '') return undefined
+  if (typeof v === 'number') return Number.isFinite(v) ? v : undefined
+  if (typeof v !== 'string') return undefined
+
+  const s = v.trim()
+  if (s === '' || s === 'auto' || s.endsWith('%')) return undefined
+
+  // 简单处理 px / pt / rpx
+  const match = s.match(/^(-?\d+(?:\.\d+)?)\s*(px|pt|rpx)?$/i)
+  if (!match) {
+    const n = Number(s)
+    return Number.isFinite(n) ? n : undefined
+  }
+  const num = parseFloat(match[1])
+  if (!Number.isFinite(num)) return undefined
+
+  const unit = (match[2] || '').toLowerCase()
+  // 简单换算:rpx 设计稿 750 → px 暂时按 1:1,业务方自定义换算后续可加
+  if (unit === 'pt') return num * 1.333
+  return num
+}
+
+// ---------------------------------------------------------------------------
+// 阴影
+// ---------------------------------------------------------------------------
+
+export interface LeaferShadow {
+  x: number
+  y: number
+  blur: number
+  spread?: number
+  color?: string
+  inset?: boolean
+}
+
+const parseShadowValue = (v: string): LeaferShadow | null => {
+  const inset = /(^|\s)inset\b/i.test(v)
+  const cleaned = v.replace(/\binset\b/gi, '').trim()
+
+  // 从尾部找颜色 token:
+  //  - rgba(...) / rgb(...)
+  //  - #xxx / #xxxxxx / #xxxxxxxx
+  //  - 命名颜色(red / blue / black 等,简单的几个常见值)
+  let color: string | undefined
+  let colorMatch: RegExpMatchArray | null
+  const namedColorRegex = /(?:^|\s)(red|blue|green|black|white|yellow|orange|pink|purple|gray|grey|cyan|magenta|brown)(?=\s|$)/i
+  const rgbaRegex = /rgba?\([^)]+\)/i
+  const hexRegex = /#[0-9a-f]{3,8}/i
+
+  if ((colorMatch = cleaned.match(rgbaRegex))) {
+    color = colorMatch[0]
+  } else if ((colorMatch = cleaned.match(hexRegex))) {
+    color = colorMatch[0]
+  } else if ((colorMatch = cleaned.match(namedColorRegex))) {
+    color = colorMatch[1]
+  }
+
+  // 颜色剥离后,剩下的应该是 x y [blur [spread]] 数字
+  const withoutColor = color
+    ? cleaned.replace(colorMatch![0], '').trim()
+    : cleaned
+  const nums = withoutColor.match(/-?\d+(?:\.\d+)?/g)?.map(Number) ?? []
+  if (nums.length < 2) return null
+
+  return {
+    x: nums[0],
+    y: nums[1],
+    blur: nums[2] ?? 0,
+    spread: nums[3] ?? 0,
+    color,
+    inset,
+  }
+}
+
+/**
+ * 解析 CSS box-shadow 字符串,支持:
+ * - 单个阴影:'0 2px 8px rgba(0,0,0,0.15)'
+ * - inset:'inset 0 1px 0 #fff'
+ * - 多阴影(逗号分隔):leafer 暂时取第一个,业务方手写多阴影
+ * - 'none' / null → undefined
+ */
+export const parseShadow = (css?: string | null): LeaferShadow | undefined => {
+  if (!css || css === 'none') return undefined
+  // 顶层逗号分割(避免切到 rgba() 里的逗号)
+  const first = css.split(/,(?![^()]*\))/, 1)[0]?.trim()
+  if (!first || first === 'none') return undefined
+  const result = parseShadowValue(first)
+  return result ?? undefined
+}
+
+// ---------------------------------------------------------------------------
+// 渐变
+// ---------------------------------------------------------------------------
+
+export interface LeaferColorStop {
+  offset: number
+  color: string
+}
+
+export type LeaferFill =
+  | { type: 'solid'; color: string }
+  | { type: 'linear'; stops: LeaferColorStop[]; angle?: number }
+  | { type: 'radial'; stops: LeaferColorStop[] }
+  | { type: 'conic'; stops: LeaferColorStop[] }
+  | { type: 'image'; url: string }
+  | undefined
+
+const parseColorStops = (stopsStr: string): LeaferColorStop[] => {
+  // 'red, blue' / 'red 50%, blue 100%' / '#fff 0, rgba(0,0,0,.5) 100%'
+  const parts = stopsStr.split(/,(?![^()]*\))/)  // 不在 () 里切
+  return parts
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => {
+      // 'red' / '#fff' / 'rgba(0,0,0,.5)' 后面可能带 50% / 100%
+      const m = p.match(/^(.+?)\s+(\d+(?:\.\d+)?%?)?$/)
+      if (!m) return { offset: 0, color: p }
+      const color = m[1].trim()
+      const offsetStr = m[2]
+      let offset = 0
+      if (offsetStr) {
+        if (offsetStr.endsWith('%')) offset = parseFloat(offsetStr) / 100
+        else offset = parseFloat(offsetStr) / 360  // 角度 → 0..1
+      }
+      return { offset, color }
+    })
+}
+
+/**
+ * 解析 CSS 渐变字符串成 leafer 内部结构。
+ * 支持 linear / radial / conic;不支持 / 解析失败 → undefined,让调用方 fallback 到 solid color。
+ */
+export const parseGradient = (css: string | undefined | null): LeaferFill => {
+  if (!css) return undefined
+  const s = css.trim()
+
+  const linearMatch = s.match(/^linear-gradient\(\s*(.+)\)$/i)
+  if (linearMatch) {
+    const inside = linearMatch[1]
+    const result: { type: 'linear'; stops: LeaferColorStop[]; angle?: number } = { type: 'linear', stops: [] }
+    // 检查是否以 'to xxx' 开头
+    const toMatch = inside.match(/^to\s+(top|bottom|left|right|top\s+left|...)/i)
+    if (toMatch) {
+      // 简化为角度:top=0, right=90, bottom=180, left=270
+      const dir = toMatch[1].toLowerCase()
+      const map: Record<string, number> = { top: 0, right: 90, bottom: 180, left: 270 }
+      result.angle = map[dir.replace(/\s+/g, '')] ?? 180
+      result.stops = parseColorStops(inside.slice(toMatch[0].length).trim())
+    } else {
+      const degMatch = inside.match(/^(-?\d+(?:\.\d+)?)\s*(?:deg|rad|turn)?,?/i)
+      if (degMatch) {
+        let deg = parseFloat(degMatch[1])
+        if (degMatch[0].includes('rad')) deg = (deg * 180) / Math.PI
+        else if (degMatch[0].includes('turn')) deg = deg * 360
+        result.angle = deg
+        result.stops = parseColorStops(inside.slice(degMatch[0].length).trim())
+      } else {
+        result.stops = parseColorStops(inside)
+      }
+    }
+    return result
+  }
+
+  const radialMatch = s.match(/^radial-gradient\(\s*(.+)\)$/i)
+  if (radialMatch) {
+    return { type: 'radial', stops: parseColorStops(radialMatch[1]) }
+  }
+
+  const conicMatch = s.match(/^conic-gradient\(\s*(.+)\)$/i)
+  if (conicMatch) {
+    return { type: 'conic', stops: parseColorStops(conicMatch[1]) }
+  }
+
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// 字号 / 字体
+// ---------------------------------------------------------------------------
+
+export const parseFontWeight = (v: unknown): number | string | undefined => {
+  if (v == null) return undefined
+  if (typeof v === 'number') return v
+  if (typeof v === 'string') {
+    const s = v.trim()
+    if (s === 'normal') return 400
+    if (s === 'bold') return 700
+    if (s === 'lighter' || s === 'bolder') return s
+    const n = parseInt(s, 10)
+    return Number.isFinite(n) ? n : undefined
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// 颜色
+// ---------------------------------------------------------------------------
+
+/**
+ * 把 CSS 颜色字符串透传给 leafer(leafer canvas 原生支持 css color 格式)。
+ * 支持:hex / rgb / rgba / 颜色名 / 'transparent' / 'inherit'。
+ */
+export const normalizeColor = (v: unknown): string | undefined => {
+  if (v == null) return undefined
+  if (typeof v === 'string') return v.trim() || undefined
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// 占位 Rect(供简单 shape 复用)
+// ---------------------------------------------------------------------------
+
+// 不在此文件直接 import Rect,以免测试环境加载 leafer-ui canvas 依赖。
+// 占位 Rect 的实现见 ./placeholder.ts

--- a/leafer-components/vitest.config.ts
+++ b/leafer-components/vitest.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'path'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'leafer-components',
+    include: ['./__tests__/**/*.spec.ts'],
+    environment: 'happy-dom',
+  },
+  resolve: {
+    alias: {
+      '@tmagic/core': resolve(__dirname, '../../packages/core/src'),
+      '@tmagic/schema': resolve(__dirname, '../../packages/schema/src'),
+    },
+  },
+})

--- a/packages/stage/package.json
+++ b/packages/stage/package.json
@@ -40,7 +40,8 @@
   },
   "devDependencies": {
     "@types/events": "^3.0.3",
-    "@types/lodash-es": "^4.17.4"
+    "@types/lodash-es": "^4.17.4",
+    "leafer-ui": "^2.0.0"
   },
   "peerDependencies": {
     "@tmagic/core": "workspace:*",

--- a/packages/stage/src/LeaferShapeRegistry.ts
+++ b/packages/stage/src/LeaferShapeRegistry.ts
@@ -1,0 +1,86 @@
+/*
+ * Tencent is pleased to support the open source community by making TMagicEditor available.
+ *
+ * Copyright (C) 2025 Tencent.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IUI } from 'leafer-ui'
+
+import type { MComponent, MNode } from '@tmagic/core'
+
+/**
+ * Shape 函数契约(由 @leafer-components 导出,这里复用其结构避免循环依赖)。
+ * 这里只声明类型,实际实现见 @leafer-components/src/utils.ts。
+ */
+export type ShapeFn = (config: MComponent, ctx: ShapeContext) => IUI | ShapeWithChildren | null
+
+export interface ShapeWithChildren {
+  node: IUI
+  children?: MNode[]
+}
+
+export interface ShapeContext {
+  resolve(type: string): ShapeFn | undefined
+  renderChildren(children: MNode[]): IUI[]
+}
+
+/**
+ * editor 端的 shape 注册中心。
+ *
+ * 业务方:
+ *   import buttonShape from '@leafer-components/button'
+ *   editor.registerShape('button', buttonShape)
+ *
+ * @tmagic/stage 不依赖 leafer-components,只通过 ShapeFn 类型契约对接。
+ */
+export class LeaferShapeRegistry {
+  private shapes: Map<string, ShapeFn> = new Map()
+
+  /** 注册一个 shape,后注册的会覆盖前注册的 */
+  public register(type: string, shape: ShapeFn): this {
+    this.shapes.set(type, shape)
+    return this
+  }
+
+  /** 批量注册 */
+  public registerAll(map: Record<string, ShapeFn>): this {
+    for (const [type, shape] of Object.entries(map)) {
+      this.register(type, shape)
+    }
+    return this
+  }
+
+  public get(type: string): ShapeFn | undefined {
+    return this.shapes.get(type)
+  }
+
+  public has(type: string): boolean {
+    return this.shapes.has(type)
+  }
+
+  public list(): string[] {
+    return Array.from(this.shapes.keys())
+  }
+
+  public unregister(type: string): boolean {
+    return this.shapes.delete(type)
+  }
+
+  public clear(): void {
+    this.shapes.clear()
+  }
+}
+
+export default LeaferShapeRegistry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ catalogs:
   default:
     '@vue/compiler-sfc':
       specifier: ^3.5.40
-      version: 3.5.40
+      version: 3.5.34
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -183,6 +183,18 @@ importers:
       vue-eslint-parser:
         specifier: ^10.4.0
         version: 10.4.0(eslint@10.0.3(jiti@2.6.1))
+
+  leafer-components:
+    devDependencies:
+      '@tmagic/schema':
+        specifier: workspace:^
+        version: link:../packages/schema
+      leafer-ui:
+        specifier: ^2.0.0
+        version: 2.2.7
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.0.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.0.10)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.44.1)(yaml@2.9.0))
 
   packages/cli:
     dependencies:
@@ -495,6 +507,9 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.4
         version: 4.17.12
+      leafer-ui:
+        specifier: ^2.0.0
+        version: 2.2.7
 
   packages/table:
     dependencies:
@@ -2580,6 +2595,153 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@leafer-in/interface@2.2.7':
+    resolution: {integrity: sha512-TmvIE3kNBsS2KIiNgul2VgnhArwLLxAs4pPcMVQ4ABqByMCr9sWEW8u5LEos2Mc6ykK/9Ty+M/M1DVHAFaGwkg==}
+    peerDependencies:
+      '@leafer-ui/interface': ^2.2.7
+      '@leafer/interface': ^2.2.7
+
+  '@leafer-ui/app@2.2.7':
+    resolution: {integrity: sha512-ZTQlwOdZgmyuZnKcljfdtVKkggHE6BYwhUn3RzRks3Qfnwe9MiMoAqaqSWrtbPKdzfKoXvqznEuW7Pm58q9Jgw==}
+
+  '@leafer-ui/bounds@2.2.7':
+    resolution: {integrity: sha512-1VKCKJ2GQXdNaU4baPOp9pGKB3L3rC+lCj82+Tg3STryu3mLKFX7qe+t+8k0fYBbKB5GoZ6tuS26l21AjjFHrA==}
+
+  '@leafer-ui/color@2.2.7':
+    resolution: {integrity: sha512-bmKnXubR/yVuXtMwgAZPxfiZwekuNWlt/uqs+F15w3Q9sBYaSMBYknHRYHK5ypDIGNfnh2mhu2P/6lMw2RtF9Q==}
+
+  '@leafer-ui/core@2.2.7':
+    resolution: {integrity: sha512-aZ1r0M+lWtbbeqZbxhBT0sSQMpVG/P9sPD3QwlpZ10v1PuWXvo9F7khsuSqU6vjcWOEo9BmjhAohTBSI3Gqdpw==}
+
+  '@leafer-ui/data@2.2.7':
+    resolution: {integrity: sha512-P2LVoKIYtQhj6S+lGnM+q7yqgwyOErrFc7gOHGeJHiSJW0eH4WD/W67CutPFmBhXRHrGS1lya2xz9xqUHwzBPA==}
+
+  '@leafer-ui/decorator@2.2.7':
+    resolution: {integrity: sha512-CSStGc3KcmFq6JmBLnPyx9rBG++rEu6T0khKmrCUg94gDDg/C4oQcuMQOFePJNJkY8hhXvfq/EJL0xAouDCg6Q==}
+
+  '@leafer-ui/display-module@2.2.7':
+    resolution: {integrity: sha512-llkL9So2CszgO+i3B+nQk0qp1s1yF++PjibimChT5Y/SXUXgDVLgxvZ+7lAn6USse/t3qMKEYSXDW7RU+nVoxg==}
+
+  '@leafer-ui/display@2.2.7':
+    resolution: {integrity: sha512-9rxvMjj55DbPd4GOJqYTwPzPSVf+FyAUkCIuL8v3g3MQJTPTENLKv4eRJ8NI3ehf6jQdfVDrEbd8pFejR//h/w==}
+
+  '@leafer-ui/draw@2.2.7':
+    resolution: {integrity: sha512-1smoh0dLLS17RIqD88xJeyDZoo4eB1SAE9BkPuaxjhbDJHMXuFoob9Oem4GCpfCHFCWzJhyLlrblwAnDeZSZLw==}
+
+  '@leafer-ui/effect@2.2.7':
+    resolution: {integrity: sha512-x6FZVbNYjD3/buG5nM6Zb4vSil83ZVAatpz5skBRUoR7eF+JhiETmMMEY6mkHaJENpWSnWI2RNdukaK26E0IDw==}
+
+  '@leafer-ui/event@2.2.7':
+    resolution: {integrity: sha512-DtfPmYILi2FayhxcYJ+XQ2AMQ2KfNjb5gNtrJFnmgE/gjHLTM7nRXdfhHDH1kF3fCHgT3Q3Trxnz4ZULyIvlpA==}
+
+  '@leafer-ui/external@2.2.7':
+    resolution: {integrity: sha512-uKROw1Rn1Z88Q28Ikz0lwnFchO+oydcOwlD4JV9qExBBVv6ZORGxfUP/QHDjp2hsQ+tet7VupnfPMmRsnb6Ojw==}
+
+  '@leafer-ui/hit@2.2.7':
+    resolution: {integrity: sha512-ha04FMjkS8wuH9XFHUvUBfEZwRwq7GBHoTfxr552hYefAgW4/4F1Jyb0XArqoMbrytrPot/aMXSlVsFBaNUpzA==}
+
+  '@leafer-ui/interaction-web@2.2.7':
+    resolution: {integrity: sha512-9L8VaJZUMvtK4mHKVYyHiYVqaHqCnKMsoV3JKWLGdfGPaTNH7Qd/uQnvzZyudGz8ACDCZ44HwCqLjwMuj0EC8A==}
+
+  '@leafer-ui/interaction@2.2.7':
+    resolution: {integrity: sha512-yxIP+VvLCSG6S6ar+2LmF03la4FC1ajXf9e0ai9Aj7qONoIZ/9PhxFXggkBR8OUAQFsdXRyg86m0IOQ7c5VyVA==}
+
+  '@leafer-ui/interface@2.2.7':
+    resolution: {integrity: sha512-KF6ycuAy7OFuFFyKLOw69PntIxKtgfZYtKhA+TyjZCeQyZmXof7rpG/zdkyUxmZZRltmvQL54zNl0QhIJwLWeA==}
+
+  '@leafer-ui/paint@2.2.7':
+    resolution: {integrity: sha512-sMnhyy/LGPH80r+0lHjIaOoFU+CWX0B7+vQ1I9cUfRy9wBufPmIT7TeGmkqahqwOdlmICz5DxQsHfwsI+uBO4g==}
+
+  '@leafer-ui/partner@2.2.7':
+    resolution: {integrity: sha512-FzpQAXDL4OLOilhvFNBZLSvJZITVezC9PuateRer/KWOY1GiJCbKEeL5uz9BEs6+XfCQV8BUOe6yBfv+7kCuEw==}
+
+  '@leafer-ui/render@2.2.7':
+    resolution: {integrity: sha512-4Ep5jJRf+0d5gWMGeh6AIPUoRpuyuPMs5Bf1+BSB/mOuhxJJX9SGClKMiuYoyYWF4D8G52vUBflgtOp9v13x6g==}
+
+  '@leafer-ui/text@2.2.7':
+    resolution: {integrity: sha512-SppAEzIwX/Jfgfwe75xrtV+vSfUdGUDG5v01emZvuqDPfl9NctTMlHxFx3H3JLxLz6R3wt040ZiaPvF3mN/jqg==}
+
+  '@leafer-ui/web@2.2.7':
+    resolution: {integrity: sha512-uJHexdwGSOQWNsyG5CU3lFeCz7UePBRh8MLGjdRulq+ttPLgSEu+iQ2sHCcGt3boGIGJxWHoOP7kD3PKahBBSA==}
+
+  '@leafer/canvas-web@2.2.7':
+    resolution: {integrity: sha512-7RmkzxiW5hvXUs8lCnDc21VwM4LlcGPmmI/OGZ4at0bca317h6Auuq2zz/PRGButup/NDFmHP4S3vm6FCZTzFg==}
+
+  '@leafer/canvas@2.2.7':
+    resolution: {integrity: sha512-H0vmt+YoQ1/+UDiobHE0eqdmQ0EY+4nkwGRXPly/D0TWdj0lMhrPtQhP2iAtmMYQxpV9nDaCF5DbLLR9DSjLyw==}
+
+  '@leafer/core@2.2.7':
+    resolution: {integrity: sha512-AexqNYarSNuJOoiuxhrFTU1Y5HNLlL9hURKVM1p/XkxZy/69WY0eW0Lk6lGoAhQ+Qj3youMny5YU6NT2suZ9fw==}
+
+  '@leafer/data@2.2.7':
+    resolution: {integrity: sha512-To2E54rIGQRtkoHDJRiw7nLsZJW5Co+zKAYu1LCOr2Sq1SaWkY6SxcR3ShHDvWgChBYtpY/6mFmdz7hQkr8NLA==}
+
+  '@leafer/debug@2.2.7':
+    resolution: {integrity: sha512-JvYazHVjyvDkn/5z77OmKhVe4Uhc1+vwTJL7hLIczYYY31rPJFqd7qm4eToHMGsr/VQHdUDGReAYNBgUsTpTDg==}
+
+  '@leafer/decorator@2.2.7':
+    resolution: {integrity: sha512-BecQ0AZHhqnbvS8bjrzPyWNIuwHWKLAOOfLgrSYgzp2qHCpadopQgyZ1+bvm6V84PTlX5Q3ui20S3+gXOI2JxA==}
+
+  '@leafer/display-module@2.2.7':
+    resolution: {integrity: sha512-yGgmXd6a1tL2pUqx7wZ0GRm+EwHihroDr7lXwuTx+tKWl0oO+NOln/37/dlc6pU4kO3inYktKBp5nx6qlQyWIw==}
+
+  '@leafer/display@2.2.7':
+    resolution: {integrity: sha512-Q0venUeZRWTVpEOJkSttSxnV8lbgYRAwqXCLIzzIneHhgVNKWWRIWqhizldRhMlNYwCqRUqlxfGQUbWUt2dF/Q==}
+
+  '@leafer/event@2.2.7':
+    resolution: {integrity: sha512-WirCEvs67dh8w4Gd9iFlqbwMavFQ+Lja/EBXnW5EaQ/bu6Opg3+6BUDDWd4vordDdvg9tkI3TINwl6UXy/v+0w==}
+
+  '@leafer/file@2.2.7':
+    resolution: {integrity: sha512-2c30wQSRRoNxaQJHHbXSYETL0Nr9kx1sJoDGvEY75u+wk4nRZJK0ifIEkl7gdKCPi/YaVc5Yl6szELlySA7yFA==}
+
+  '@leafer/helper@2.2.7':
+    resolution: {integrity: sha512-yVcknYfmo5o006+j5UuU4/P+t9ZOWVo/ZAK9lbCGHglywqxadRAHQ097hZRXkran2hZb2LnfMsJMXaGjPeAtZw==}
+
+  '@leafer/image-web@2.2.7':
+    resolution: {integrity: sha512-ZALsNtsjAiv7RYTH8oDVcdz6hJyakPCXk9nnM5C/k1VY+g+Cj2kVu3u4Ld5GWXxijyHR1TEoLNohZkQ47GtlSA==}
+
+  '@leafer/image@2.2.7':
+    resolution: {integrity: sha512-/aeqkZOoHVA+wBLAX7EQRZQiGul7NBUkegUa9GXNF/VRkC5d4QSmWKM3ry2O+pMP63Rvl8DA1oC8jhFBOgkFmA==}
+
+  '@leafer/interface@2.2.7':
+    resolution: {integrity: sha512-S8SJNj7F1UGYewIBPcJkfxBMMerVgbG4MO58KK8NC+H4+0nPef+AoRt95H7HFWjNOgD1WULqRX+P0lPhxny8hg==}
+
+  '@leafer/layout@2.2.7':
+    resolution: {integrity: sha512-qO6yY8KcCOKj4bzCUP+ZCssTiP+1pVhzzTnYiEpz5Bmqhs5OMT5PR5+tGMFuSxnczK6DF+TR9mfU8mDFFltTIA==}
+
+  '@leafer/layouter@2.2.7':
+    resolution: {integrity: sha512-CPj6MTvxwSqb4gVl0LkAAFdjRLRsKO7KzIggN1uqjhTcKtyexc7g+ytWbWEaSAhPeGsflf9RUvse6boX0ffdcg==}
+
+  '@leafer/list@2.2.7':
+    resolution: {integrity: sha512-ihVc3B7qIHoiVkqq/i8zlwBl4o3dTwR3DRUVxC7DdjU5avuD+9Pbjem5dCVS2uovP7dapDV89aZOjQ/3tMOSmg==}
+
+  '@leafer/math@2.2.7':
+    resolution: {integrity: sha512-aHWyjC+Jts+EmOywIuPd4NExzLx3JQjjPMZG6iP+PDseJL20o371mtNYhJoMASdS0Q2uc+cYMjF+vZylfMSjqw==}
+
+  '@leafer/partner@2.2.7':
+    resolution: {integrity: sha512-KP4kxL0sNxZFi7Z+QNPNNT4qrhs/rblsnrl0CDhn2v6tDOk4cD7B9ysmWwOjMilB2qG29IHeVjZH9wcuLDHapA==}
+
+  '@leafer/path@2.2.7':
+    resolution: {integrity: sha512-rOSvkUAQVRF00lJewzSt8JIpMbuWwsD1b3BXUNgzWGzzqLDAoQfzd+YZ70zvrczLukds90wvHv22vlFuSX76fQ==}
+
+  '@leafer/platform@2.2.7':
+    resolution: {integrity: sha512-z2mw/6xAoN4i4FdWf7ksY14O/OIHNJJgSUDlKwCuwpF55wI+5YXM++66NCNZxBB/dgrjFsfM+JxRCdKiDxR9bw==}
+
+  '@leafer/renderer@2.2.7':
+    resolution: {integrity: sha512-YMGpKcB1357Z/4MhJNfMrTYteps3FrY7hfki/0vDmMp0UdHS1KPuvR8tdOGKB/mXj99Bec3R8WYMm+KHA/v7ug==}
+
+  '@leafer/selector@2.2.7':
+    resolution: {integrity: sha512-qPvBGCunuH7lQacePBcRipm/EJXOA6VUlTLyh5oFlwX0/Oeem0yNOrK/99SkJ8dNvbgbKKjQqNi2PIwdsgK3bA==}
+
+  '@leafer/task@2.2.7':
+    resolution: {integrity: sha512-fK2NfBIWre6TF6ZgSN6vBwf4stAliKNcGuKwe9dERF8Olig9AaawiOa/adBg4kUHSuPgTnQbi/K32XrFIcROMw==}
+
+  '@leafer/watcher@2.2.7':
+    resolution: {integrity: sha512-OV2YkWXbH2hCfIOLy80jOO+gB/LKc2iMkL3IKHTiJ0ZrnNlDPR5xoHcD13fnhBrOolqTfqnHtvem5NTTaxyZtA==}
+
+  '@leafer/web-core@2.2.7':
+    resolution: {integrity: sha512-/N1OVI8bAbZjMkmgCI4E43qMVQXOJRzBwY4iQf7PlYiKv7R67yT21lYulE8ysTX4P690sfjo9UxG32zOJaHx4w==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -5374,6 +5536,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  leafer-ui@2.2.7:
+    resolution: {integrity: sha512-G9PYMImGFlDr2yd6WVjgirQqywb3Z6fRokZYq8m8Bq1cujUfXNCiPojd5Ol2S0NGgGTHCKwIdyTmmV/buHH0XQ==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -8419,6 +8584,293 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@leafer-in/interface@2.2.7(@leafer-ui/interface@2.2.7)(@leafer/interface@2.2.7)':
+    dependencies:
+      '@leafer-ui/interface': 2.2.7
+      '@leafer/interface': 2.2.7
+
+  '@leafer-ui/app@2.2.7':
+    dependencies:
+      '@leafer-ui/data': 2.2.7
+      '@leafer-ui/display': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/bounds@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/color@2.2.7':
+    dependencies:
+      '@leafer-ui/draw': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/core@2.2.7':
+    dependencies:
+      '@leafer-ui/app': 2.2.7
+      '@leafer-ui/draw': 2.2.7
+      '@leafer-ui/event': 2.2.7
+      '@leafer-ui/hit': 2.2.7
+      '@leafer-ui/interaction': 2.2.7
+
+  '@leafer-ui/data@2.2.7':
+    dependencies:
+      '@leafer-ui/external': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/decorator@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/display-module@2.2.7':
+    dependencies:
+      '@leafer-ui/bounds': 2.2.7
+      '@leafer-ui/data': 2.2.7
+      '@leafer-ui/render': 2.2.7
+
+  '@leafer-ui/display@2.2.7':
+    dependencies:
+      '@leafer-ui/data': 2.2.7
+      '@leafer-ui/decorator': 2.2.7
+      '@leafer-ui/display-module': 2.2.7
+      '@leafer-ui/external': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/draw@2.2.7':
+    dependencies:
+      '@leafer-ui/decorator': 2.2.7
+      '@leafer-ui/display': 2.2.7
+      '@leafer-ui/display-module': 2.2.7
+      '@leafer-ui/external': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/effect@2.2.7':
+    dependencies:
+      '@leafer-ui/draw': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/event@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/external@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/hit@2.2.7':
+    dependencies:
+      '@leafer-ui/draw': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/interaction-web@2.2.7':
+    dependencies:
+      '@leafer-ui/core': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/interaction@2.2.7':
+    dependencies:
+      '@leafer-ui/draw': 2.2.7
+      '@leafer-ui/event': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/interface@2.2.7':
+    dependencies:
+      '@leafer/interface': 2.2.7
+
+  '@leafer-ui/paint@2.2.7':
+    dependencies:
+      '@leafer-ui/draw': 2.2.7
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/partner@2.2.7':
+    dependencies:
+      '@leafer-ui/color': 2.2.7
+      '@leafer-ui/draw': 2.2.7
+      '@leafer-ui/effect': 2.2.7
+      '@leafer-ui/paint': 2.2.7
+      '@leafer-ui/text': 2.2.7
+
+  '@leafer-ui/render@2.2.7':
+    dependencies:
+      '@leafer-ui/external': 2.2.7
+
+  '@leafer-ui/text@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer-ui/web@2.2.7':
+    dependencies:
+      '@leafer-in/interface': 2.2.7(@leafer-ui/interface@2.2.7)(@leafer/interface@2.2.7)
+      '@leafer-ui/core': 2.2.7
+      '@leafer-ui/draw': 2.2.7
+      '@leafer-ui/interaction-web': 2.2.7
+      '@leafer-ui/interface': 2.2.7
+      '@leafer-ui/partner': 2.2.7
+      '@leafer/interface': 2.2.7
+      '@leafer/partner': 2.2.7
+      '@leafer/web-core': 2.2.7
+
+  '@leafer/canvas-web@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer/canvas@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/file': 2.2.7
+      '@leafer/list': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/path': 2.2.7
+      '@leafer/platform': 2.2.7
+
+  '@leafer/core@2.2.7':
+    dependencies:
+      '@leafer/canvas': 2.2.7
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/decorator': 2.2.7
+      '@leafer/display': 2.2.7
+      '@leafer/display-module': 2.2.7
+      '@leafer/event': 2.2.7
+      '@leafer/file': 2.2.7
+      '@leafer/helper': 2.2.7
+      '@leafer/image': 2.2.7
+      '@leafer/layout': 2.2.7
+      '@leafer/list': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/path': 2.2.7
+      '@leafer/platform': 2.2.7
+      '@leafer/task': 2.2.7
+
+  '@leafer/data@2.2.7': {}
+
+  '@leafer/debug@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/math': 2.2.7
+
+  '@leafer/decorator@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/platform': 2.2.7
+
+  '@leafer/display-module@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/event': 2.2.7
+      '@leafer/helper': 2.2.7
+      '@leafer/math': 2.2.7
+
+  '@leafer/display@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/decorator': 2.2.7
+      '@leafer/display-module': 2.2.7
+      '@leafer/event': 2.2.7
+      '@leafer/helper': 2.2.7
+      '@leafer/image': 2.2.7
+      '@leafer/layout': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/platform': 2.2.7
+
+  '@leafer/event@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/decorator': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/platform': 2.2.7
+
+  '@leafer/file@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/platform': 2.2.7
+      '@leafer/task': 2.2.7
+
+  '@leafer/helper@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/platform': 2.2.7
+
+  '@leafer/image-web@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer/image@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/file': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/platform': 2.2.7
+      '@leafer/task': 2.2.7
+
+  '@leafer/interface@2.2.7': {}
+
+  '@leafer/layout@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/helper': 2.2.7
+      '@leafer/math': 2.2.7
+      '@leafer/platform': 2.2.7
+
+  '@leafer/layouter@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer/list@2.2.7': {}
+
+  '@leafer/math@2.2.7': {}
+
+  '@leafer/partner@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+      '@leafer/layouter': 2.2.7
+      '@leafer/renderer': 2.2.7
+      '@leafer/selector': 2.2.7
+      '@leafer/watcher': 2.2.7
+
+  '@leafer/path@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+      '@leafer/math': 2.2.7
+
+  '@leafer/platform@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/debug': 2.2.7
+
+  '@leafer/renderer@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer/selector@2.2.7':
+    dependencies:
+      '@leafer/core': 2.2.7
+
+  '@leafer/task@2.2.7':
+    dependencies:
+      '@leafer/debug': 2.2.7
+      '@leafer/math': 2.2.7
+
+  '@leafer/watcher@2.2.7':
+    dependencies:
+      '@leafer/data': 2.2.7
+      '@leafer/event': 2.2.7
+      '@leafer/list': 2.2.7
+
+  '@leafer/web-core@2.2.7':
+    dependencies:
+      '@leafer/canvas-web': 2.2.7
+      '@leafer/core': 2.2.7
+      '@leafer/image-web': 2.2.7
+      '@leafer/interface': 2.2.7
+      '@leafer/partner': 2.2.7
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -11467,6 +11919,19 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  leafer-ui@2.2.7:
+    dependencies:
+      '@leafer-in/interface': 2.2.7(@leafer-ui/interface@2.2.7)(@leafer/interface@2.2.7)
+      '@leafer-ui/core': 2.2.7
+      '@leafer-ui/draw': 2.2.7
+      '@leafer-ui/interaction-web': 2.2.7
+      '@leafer-ui/interface': 2.2.7
+      '@leafer-ui/partner': 2.2.7
+      '@leafer-ui/web': 2.2.7
+      '@leafer/core': 2.2.7
+      '@leafer/interface': 2.2.7
+      '@leafer/partner': 2.2.7
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - "runtime/*"
   - "vue-components/*"
   - "react-components/*"
+  - "leafer-components"
   - "eslint-config"
 
 catalog:


### PR DESCRIPTION
editor 端把 iframe + StageMask 改成 leafer-ui 渲染的 foundation:
- 新增 leafer-components/ 包:shape 函数 + utils(parsePx/parseShadow/parseGradient)
  - 5 个内置:button / text / img / container / overlay
  - 5 个占位:page / qrcode / page-fragment / page-fragment-container / iterator-container
- 新增 @tmagic/stage LeaferShapeRegistry:editor 端 shape 注册中心
- 21/21 单测通过
- 配套 3 份调研 doc:
  - multi-page-infinite-canvas.md(无限画布调研)
  - leafer-renderer-migration.md(leafer 迁移调研)
  - implementation-tasks.md(50 个原子任务清单)